### PR TITLE
Better handling of SQLSTATE

### DIFF
--- a/tests/create-table.sql
+++ b/tests/create-table.sql
@@ -49,7 +49,7 @@ CREATE TABLE bar (baz VARCHAR(10))
 CREATE TABLE foo (a FLOAT)
 CREATE TABLE foo (baz CHARACTER VARYING(10))
 -- msg: CREATE TABLE 1
--- error: vsql.SQLState42P07: duplicate table: FOO
+-- error 42P07: duplicate table: FOO
 
 CREATE TABLE t1 (f1 CHARACTER VARYING(10), f2 FLOAT)
 -- msg: CREATE TABLE 1
@@ -57,7 +57,7 @@ CREATE TABLE t1 (f1 CHARACTER VARYING(10), f2 FLOAT)
 CREATE TABLE foo (a FLOAT)
 CREATE TABLE Foo (baz CHARACTER VARYING(10))
 -- msg: CREATE TABLE 1
--- error: vsql.SQLState42P07: duplicate table: FOO
+-- error 42P07: duplicate table: FOO
 
 CREATE TABLE "foo" (a FLOAT)
 CREATE TABLE "Foo" (baz CHARACTER VARYING(10))

--- a/tests/delete.sql
+++ b/tests/delete.sql
@@ -1,5 +1,5 @@
 DELETE FROM foo
--- error: vsql.SQLState42P01: no such table: FOO
+-- error 42P01: no such table: FOO
 
 CREATE TABLE foo (baz CHARACTER VARYING(10))
 INSERT INTO foo (baz) VALUES ('hi')

--- a/tests/drop-table.sql
+++ b/tests/drop-table.sql
@@ -1,9 +1,9 @@
 DROP TABLE foo
--- error: vsql.SQLState42P01: no such table: FOO
+-- error 42P01: no such table: FOO
 
 CREATE TABLE foo (a FLOAT)
 DROP TABLE foo
 DROP TABLE foo
 -- msg: CREATE TABLE 1
 -- msg: DROP TABLE 1
--- error: vsql.SQLState42P01: no such table: FOO
+-- error 42P01: no such table: FOO

--- a/tests/errors.sql
+++ b/tests/errors.sql
@@ -1,2 +1,2 @@
 TABLE
--- error: vsql.SQLState42601: syntax error: at "TABLE"
+-- error 42601: syntax error: at "TABLE"

--- a/tests/insert.sql
+++ b/tests/insert.sql
@@ -29,25 +29,25 @@ SELECT * FROM foo
 CREATE TABLE foo (b BOOLEAN)
 INSERT INTO foo (b) VALUES (123, 456)
 -- msg: CREATE TABLE 1
--- error: vsql.SQLState42601: syntax error: INSERT has more values than columns
+-- error 42601: syntax error: INSERT has more values than columns
 
 CREATE TABLE foo (b BOOLEAN, c INT)
 INSERT INTO foo (b, c) VALUES (123)
 -- msg: CREATE TABLE 1
--- error: vsql.SQLState42601: syntax error: INSERT has less values than columns
+-- error 42601: syntax error: INSERT has less values than columns
 
 INSERT INTO foo (b) VALUES (123)
--- error: vsql.SQLState42P01: no such table: FOO
+-- error 42P01: no such table: FOO
 
 CREATE TABLE foo (b BOOLEAN)
 INSERT INTO foo (c) VALUES (true)
 -- msg: CREATE TABLE 1
--- error: vsql.SQLState42703: no such column: C
+-- error 42703: no such column: C
 
 CREATE TABLE foo (b BOOLEAN)
 INSERT INTO foo (b) VALUES (123)
 -- msg: CREATE TABLE 1
--- error: vsql.SQLState42804: data type mismatch for column B: expected BOOLEAN but got INTEGER
+-- error 42804: data type mismatch for column B: expected BOOLEAN but got INTEGER
 
 CREATE TABLE t1 (f1 CHARACTER VARYING(10) NULL, f2 FLOAT NOT NULL)
 INSERT INTO t1 (f1, f2) VALUES ('a', 1.23)
@@ -60,7 +60,7 @@ CREATE TABLE t1 (f1 CHARACTER VARYING(10) NULL, f2 FLOAT NOT NULL)
 INSERT INTO t1 (f1, f2) VALUES ('a', NULL)
 SELECT * FROM t1
 -- msg: CREATE TABLE 1
--- error: vsql.SQLState42804: violates non-null constraint: column F2
+-- error 23502: violates non-null constraint: column F2
 
 CREATE TABLE t1 (f1 CHARACTER VARYING(10) NULL, f2 FLOAT NOT NULL)
 INSERT INTO t1 (f1, f2) VALUES (NULL, 1.23)
@@ -87,4 +87,4 @@ CREATE TABLE t1 (f1 CHARACTER VARYING(10) NULL, f2 FLOAT NOT NULL)
 INSERT INTO t1 (f1) VALUES ('a')
 SELECT * FROM t1
 -- msg: CREATE TABLE 1
--- error: vsql.SQLState42804: violates non-null constraint: column F2
+-- error 23502: violates non-null constraint: column F2

--- a/tests/reserved-words.sql
+++ b/tests/reserved-words.sql
@@ -1,1106 +1,1106 @@
 CREATE TABLE ABS (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ABS
+-- error 42601: syntax error: table name cannot be reserved word: ABS
 
 CREATE TABLE ACOS (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ACOS
+-- error 42601: syntax error: table name cannot be reserved word: ACOS
 
 CREATE TABLE ALL (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ALL
+-- error 42601: syntax error: table name cannot be reserved word: ALL
 
 CREATE TABLE ALLOCATE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ALLOCATE
+-- error 42601: syntax error: table name cannot be reserved word: ALLOCATE
 
 CREATE TABLE ALTER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ALTER
+-- error 42601: syntax error: table name cannot be reserved word: ALTER
 
 CREATE TABLE AND (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: AND
+-- error 42601: syntax error: table name cannot be reserved word: AND
 
 CREATE TABLE ANY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ANY
+-- error 42601: syntax error: table name cannot be reserved word: ANY
 
 CREATE TABLE ARE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ARE
+-- error 42601: syntax error: table name cannot be reserved word: ARE
 
 CREATE TABLE ARRAY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ARRAY
+-- error 42601: syntax error: table name cannot be reserved word: ARRAY
 
 CREATE TABLE ARRAY_AGG (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ARRAY_AGG
+-- error 42601: syntax error: table name cannot be reserved word: ARRAY_AGG
 
 CREATE TABLE ARRAY_MAX_CARDINALITY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ARRAY_MAX_CARDINALITY
+-- error 42601: syntax error: table name cannot be reserved word: ARRAY_MAX_CARDINALITY
 
 CREATE TABLE AS (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: AS
+-- error 42601: syntax error: table name cannot be reserved word: AS
 
 CREATE TABLE ASENSITIVE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ASENSITIVE
+-- error 42601: syntax error: table name cannot be reserved word: ASENSITIVE
 
 CREATE TABLE ASIN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ASIN
+-- error 42601: syntax error: table name cannot be reserved word: ASIN
 
 CREATE TABLE ASYMMETRIC (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ASYMMETRIC
+-- error 42601: syntax error: table name cannot be reserved word: ASYMMETRIC
 
 CREATE TABLE AT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: AT
+-- error 42601: syntax error: table name cannot be reserved word: AT
 
 CREATE TABLE ATAN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ATAN
+-- error 42601: syntax error: table name cannot be reserved word: ATAN
 
 CREATE TABLE ATOMIC (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ATOMIC
+-- error 42601: syntax error: table name cannot be reserved word: ATOMIC
 
 CREATE TABLE AUTHORIZATION (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: AUTHORIZATION
+-- error 42601: syntax error: table name cannot be reserved word: AUTHORIZATION
 
 CREATE TABLE AVG (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: AVG
+-- error 42601: syntax error: table name cannot be reserved word: AVG
 
 CREATE TABLE BEGIN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: BEGIN
+-- error 42601: syntax error: table name cannot be reserved word: BEGIN
 
 CREATE TABLE BEGIN_FRAME (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: BEGIN_FRAME
+-- error 42601: syntax error: table name cannot be reserved word: BEGIN_FRAME
 
 CREATE TABLE BEGIN_PARTITION (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: BEGIN_PARTITION
+-- error 42601: syntax error: table name cannot be reserved word: BEGIN_PARTITION
 
 CREATE TABLE BETWEEN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: BETWEEN
+-- error 42601: syntax error: table name cannot be reserved word: BETWEEN
 
 CREATE TABLE BIGINT (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found BIGINT
+-- error 42601: syntax error: expecting literal_identifier but found BIGINT
 
 CREATE TABLE BINARY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: BINARY
+-- error 42601: syntax error: table name cannot be reserved word: BINARY
 
 CREATE TABLE BLOB (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: BLOB
+-- error 42601: syntax error: table name cannot be reserved word: BLOB
 
 CREATE TABLE BOOLEAN (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found BOOLEAN
+-- error 42601: syntax error: expecting literal_identifier but found BOOLEAN
 
 CREATE TABLE BOTH (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: BOTH
+-- error 42601: syntax error: table name cannot be reserved word: BOTH
 
 CREATE TABLE BY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: BY
+-- error 42601: syntax error: table name cannot be reserved word: BY
 
 CREATE TABLE CALL (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CALL
+-- error 42601: syntax error: table name cannot be reserved word: CALL
 
 CREATE TABLE CALLED (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CALLED
+-- error 42601: syntax error: table name cannot be reserved word: CALLED
 
 CREATE TABLE CARDINALITY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CARDINALITY
+-- error 42601: syntax error: table name cannot be reserved word: CARDINALITY
 
 CREATE TABLE CASCADED (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CASCADED
+-- error 42601: syntax error: table name cannot be reserved word: CASCADED
 
 CREATE TABLE CASE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CASE
+-- error 42601: syntax error: table name cannot be reserved word: CASE
 
 CREATE TABLE CAST (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CAST
+-- error 42601: syntax error: table name cannot be reserved word: CAST
 
 CREATE TABLE CEIL (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CEIL
+-- error 42601: syntax error: table name cannot be reserved word: CEIL
 
 CREATE TABLE CEILING (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CEILING
+-- error 42601: syntax error: table name cannot be reserved word: CEILING
 
 CREATE TABLE CHAR (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found CHAR
+-- error 42601: syntax error: expecting literal_identifier but found CHAR
 
 CREATE TABLE CHAR_LENGTH (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CHAR_LENGTH
+-- error 42601: syntax error: table name cannot be reserved word: CHAR_LENGTH
 
 CREATE TABLE CHARACTER (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found CHARACTER
+-- error 42601: syntax error: expecting literal_identifier but found CHARACTER
 
 CREATE TABLE CHARACTER_LENGTH (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CHARACTER_LENGTH
+-- error 42601: syntax error: table name cannot be reserved word: CHARACTER_LENGTH
 
 CREATE TABLE CHECK (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CHECK
+-- error 42601: syntax error: table name cannot be reserved word: CHECK
 
 CREATE TABLE CLASSIFIER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CLASSIFIER
+-- error 42601: syntax error: table name cannot be reserved word: CLASSIFIER
 
 CREATE TABLE CLOB (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CLOB
+-- error 42601: syntax error: table name cannot be reserved word: CLOB
 
 CREATE TABLE CLOSE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CLOSE
+-- error 42601: syntax error: table name cannot be reserved word: CLOSE
 
 CREATE TABLE COALESCE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: COALESCE
+-- error 42601: syntax error: table name cannot be reserved word: COALESCE
 
 CREATE TABLE COLLATE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: COLLATE
+-- error 42601: syntax error: table name cannot be reserved word: COLLATE
 
 CREATE TABLE COLLECT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: COLLECT
+-- error 42601: syntax error: table name cannot be reserved word: COLLECT
 
 CREATE TABLE COLUMN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: COLUMN
+-- error 42601: syntax error: table name cannot be reserved word: COLUMN
 
 CREATE TABLE COMMIT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: COMMIT
+-- error 42601: syntax error: table name cannot be reserved word: COMMIT
 
 CREATE TABLE CONDITION (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CONDITION
+-- error 42601: syntax error: table name cannot be reserved word: CONDITION
 
 CREATE TABLE CONNECT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CONNECT
+-- error 42601: syntax error: table name cannot be reserved word: CONNECT
 
 CREATE TABLE CONSTRAINT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CONSTRAINT
+-- error 42601: syntax error: table name cannot be reserved word: CONSTRAINT
 
 CREATE TABLE CONTAINS (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CONTAINS
+-- error 42601: syntax error: table name cannot be reserved word: CONTAINS
 
 CREATE TABLE CONVERT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CONVERT
+-- error 42601: syntax error: table name cannot be reserved word: CONVERT
 
 CREATE TABLE COPY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: COPY
+-- error 42601: syntax error: table name cannot be reserved word: COPY
 
 CREATE TABLE CORR (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CORR
+-- error 42601: syntax error: table name cannot be reserved word: CORR
 
 CREATE TABLE CORRESPONDING (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CORRESPONDING
+-- error 42601: syntax error: table name cannot be reserved word: CORRESPONDING
 
 CREATE TABLE COS (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: COS
+-- error 42601: syntax error: table name cannot be reserved word: COS
 
 CREATE TABLE COSH (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: COSH
+-- error 42601: syntax error: table name cannot be reserved word: COSH
 
 CREATE TABLE COUNT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: COUNT
+-- error 42601: syntax error: table name cannot be reserved word: COUNT
 
 CREATE TABLE COVAR_POP (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: COVAR_POP
+-- error 42601: syntax error: table name cannot be reserved word: COVAR_POP
 
 CREATE TABLE COVAR_SAMP (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: COVAR_SAMP
+-- error 42601: syntax error: table name cannot be reserved word: COVAR_SAMP
 
 CREATE TABLE CREATE (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found CREATE
+-- error 42601: syntax error: expecting literal_identifier but found CREATE
 
 CREATE TABLE CROSS (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CROSS
+-- error 42601: syntax error: table name cannot be reserved word: CROSS
 
 CREATE TABLE CUBE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CUBE
+-- error 42601: syntax error: table name cannot be reserved word: CUBE
 
 CREATE TABLE CUME_DIST (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CUME_DIST
+-- error 42601: syntax error: table name cannot be reserved word: CUME_DIST
 
 CREATE TABLE CURRENT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CURRENT
+-- error 42601: syntax error: table name cannot be reserved word: CURRENT
 
 CREATE TABLE CURRENT_CATALOG (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CURRENT_CATALOG
+-- error 42601: syntax error: table name cannot be reserved word: CURRENT_CATALOG
 
 CREATE TABLE CURRENT_DATE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CURRENT_DATE
+-- error 42601: syntax error: table name cannot be reserved word: CURRENT_DATE
 
 CREATE TABLE CURRENT_DEFAULT_TRANSFORM_GROUP (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CURRENT_DEFAULT_TRANSFORM_GROUP
+-- error 42601: syntax error: table name cannot be reserved word: CURRENT_DEFAULT_TRANSFORM_GROUP
 
 CREATE TABLE CURRENT_PATH (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CURRENT_PATH
+-- error 42601: syntax error: table name cannot be reserved word: CURRENT_PATH
 
 CREATE TABLE CURRENT_ROLE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CURRENT_ROLE
+-- error 42601: syntax error: table name cannot be reserved word: CURRENT_ROLE
 
 CREATE TABLE CURRENT_ROW (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CURRENT_ROW
+-- error 42601: syntax error: table name cannot be reserved word: CURRENT_ROW
 
 CREATE TABLE CURRENT_SCHEMA (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CURRENT_SCHEMA
+-- error 42601: syntax error: table name cannot be reserved word: CURRENT_SCHEMA
 
 CREATE TABLE CURRENT_TIME (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CURRENT_TIME
+-- error 42601: syntax error: table name cannot be reserved word: CURRENT_TIME
 
 CREATE TABLE CURRENT_TIMESTAMP (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CURRENT_TIMESTAMP
+-- error 42601: syntax error: table name cannot be reserved word: CURRENT_TIMESTAMP
 
 CREATE TABLE CURRENT_PATH (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CURRENT_PATH
+-- error 42601: syntax error: table name cannot be reserved word: CURRENT_PATH
 
 CREATE TABLE CURRENT_ROLE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CURRENT_ROLE
+-- error 42601: syntax error: table name cannot be reserved word: CURRENT_ROLE
 
 CREATE TABLE CURRENT_TRANSFORM_GROUP_FOR_TYPE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CURRENT_TRANSFORM_GROUP_FOR_TYPE
+-- error 42601: syntax error: table name cannot be reserved word: CURRENT_TRANSFORM_GROUP_FOR_TYPE
 
 CREATE TABLE CURRENT_USER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CURRENT_USER
+-- error 42601: syntax error: table name cannot be reserved word: CURRENT_USER
 
 CREATE TABLE CURSOR (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CURSOR
+-- error 42601: syntax error: table name cannot be reserved word: CURSOR
 
 CREATE TABLE CYCLE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: CYCLE
+-- error 42601: syntax error: table name cannot be reserved word: CYCLE
 
 CREATE TABLE DATE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DATE
+-- error 42601: syntax error: table name cannot be reserved word: DATE
 
 CREATE TABLE DAY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DAY
+-- error 42601: syntax error: table name cannot be reserved word: DAY
 
 CREATE TABLE DEALLOCATE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DEALLOCATE
+-- error 42601: syntax error: table name cannot be reserved word: DEALLOCATE
 
 CREATE TABLE DEC (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DEC
+-- error 42601: syntax error: table name cannot be reserved word: DEC
 
 CREATE TABLE DECIMAL (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DECIMAL
+-- error 42601: syntax error: table name cannot be reserved word: DECIMAL
 
 CREATE TABLE DECFLOAT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DECFLOAT
+-- error 42601: syntax error: table name cannot be reserved word: DECFLOAT
 
 CREATE TABLE DECLARE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DECLARE
+-- error 42601: syntax error: table name cannot be reserved word: DECLARE
 
 CREATE TABLE DEFAULT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DEFAULT
+-- error 42601: syntax error: table name cannot be reserved word: DEFAULT
 
 CREATE TABLE DEFINE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DEFINE
+-- error 42601: syntax error: table name cannot be reserved word: DEFINE
 
 CREATE TABLE DELETE (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found DELETE
+-- error 42601: syntax error: expecting literal_identifier but found DELETE
 
 CREATE TABLE DENSE_RANK (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DENSE_RANK
+-- error 42601: syntax error: table name cannot be reserved word: DENSE_RANK
 
 CREATE TABLE DEREF (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DEREF
+-- error 42601: syntax error: table name cannot be reserved word: DEREF
 
 CREATE TABLE DESCRIBE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DESCRIBE
+-- error 42601: syntax error: table name cannot be reserved word: DESCRIBE
 
 CREATE TABLE DETERMINISTIC (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DETERMINISTIC
+-- error 42601: syntax error: table name cannot be reserved word: DETERMINISTIC
 
 CREATE TABLE DISCONNECT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DISCONNECT
+-- error 42601: syntax error: table name cannot be reserved word: DISCONNECT
 
 CREATE TABLE DISTINCT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DISTINCT
+-- error 42601: syntax error: table name cannot be reserved word: DISTINCT
 
 CREATE TABLE DOUBLE (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found DOUBLE
+-- error 42601: syntax error: expecting literal_identifier but found DOUBLE
 
 CREATE TABLE DROP (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found DROP
+-- error 42601: syntax error: expecting literal_identifier but found DROP
 
 CREATE TABLE DYNAMIC (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: DYNAMIC
+-- error 42601: syntax error: table name cannot be reserved word: DYNAMIC
 
 CREATE TABLE EACH (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: EACH
+-- error 42601: syntax error: table name cannot be reserved word: EACH
 
 CREATE TABLE ELEMENT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ELEMENT
+-- error 42601: syntax error: table name cannot be reserved word: ELEMENT
 
 CREATE TABLE ELSE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ELSE
+-- error 42601: syntax error: table name cannot be reserved word: ELSE
 
 CREATE TABLE EMPTY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: EMPTY
+-- error 42601: syntax error: table name cannot be reserved word: EMPTY
 
 CREATE TABLE END (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: END
+-- error 42601: syntax error: table name cannot be reserved word: END
 
 CREATE TABLE END_FRAME (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: END_FRAME
+-- error 42601: syntax error: table name cannot be reserved word: END_FRAME
 
 CREATE TABLE END_PARTITION (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: END_PARTITION
+-- error 42601: syntax error: table name cannot be reserved word: END_PARTITION
 
 CREATE TABLE END-EXEC (a INT)
--- error: vsql.SQLState42601: syntax error: expecting op_paren_open but found EXEC
+-- error 42601: syntax error: expecting op_paren_open but found EXEC
 
 CREATE TABLE EQUALS (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: EQUALS
+-- error 42601: syntax error: table name cannot be reserved word: EQUALS
 
 CREATE TABLE ESCAPE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ESCAPE
+-- error 42601: syntax error: table name cannot be reserved word: ESCAPE
 
 CREATE TABLE EVERY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: EVERY
+-- error 42601: syntax error: table name cannot be reserved word: EVERY
 
 CREATE TABLE EXCEPT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: EXCEPT
+-- error 42601: syntax error: table name cannot be reserved word: EXCEPT
 
 CREATE TABLE EXEC (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: EXEC
+-- error 42601: syntax error: table name cannot be reserved word: EXEC
 
 CREATE TABLE EXECUTE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: EXECUTE
+-- error 42601: syntax error: table name cannot be reserved word: EXECUTE
 
 CREATE TABLE EXISTS (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: EXISTS
+-- error 42601: syntax error: table name cannot be reserved word: EXISTS
 
 CREATE TABLE EXP (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: EXP
+-- error 42601: syntax error: table name cannot be reserved word: EXP
 
 CREATE TABLE EXTERNAL (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: EXTERNAL
+-- error 42601: syntax error: table name cannot be reserved word: EXTERNAL
 
 CREATE TABLE EXTRACT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: EXTRACT
+-- error 42601: syntax error: table name cannot be reserved word: EXTRACT
 
 CREATE TABLE FALSE (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found FALSE
+-- error 42601: syntax error: expecting literal_identifier but found FALSE
 
 CREATE TABLE FETCH (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: FETCH
+-- error 42601: syntax error: table name cannot be reserved word: FETCH
 
 CREATE TABLE FILTER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: FILTER
+-- error 42601: syntax error: table name cannot be reserved word: FILTER
 
 CREATE TABLE FIRST_VALUE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: FIRST_VALUE
+-- error 42601: syntax error: table name cannot be reserved word: FIRST_VALUE
 
 CREATE TABLE FLOAT (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found FLOAT
+-- error 42601: syntax error: expecting literal_identifier but found FLOAT
 
 CREATE TABLE FLOOR (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: FLOOR
+-- error 42601: syntax error: table name cannot be reserved word: FLOOR
 
 CREATE TABLE FOR (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: FOR
+-- error 42601: syntax error: table name cannot be reserved word: FOR
 
 CREATE TABLE FOREIGN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: FOREIGN
+-- error 42601: syntax error: table name cannot be reserved word: FOREIGN
 
 CREATE TABLE FRAME_ROW (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: FRAME_ROW
+-- error 42601: syntax error: table name cannot be reserved word: FRAME_ROW
 
 CREATE TABLE FREE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: FREE
+-- error 42601: syntax error: table name cannot be reserved word: FREE
 
 CREATE TABLE FROM (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found FROM
+-- error 42601: syntax error: expecting literal_identifier but found FROM
 
 CREATE TABLE FULL (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: FULL
+-- error 42601: syntax error: table name cannot be reserved word: FULL
 
 CREATE TABLE FUNCTION (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: FUNCTION
+-- error 42601: syntax error: table name cannot be reserved word: FUNCTION
 
 CREATE TABLE FUSION (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: FUSION
+-- error 42601: syntax error: table name cannot be reserved word: FUSION
 
 CREATE TABLE GET (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: GET
+-- error 42601: syntax error: table name cannot be reserved word: GET
 
 CREATE TABLE GLOBAL (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: GLOBAL
+-- error 42601: syntax error: table name cannot be reserved word: GLOBAL
 
 CREATE TABLE GRANT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: GRANT
+-- error 42601: syntax error: table name cannot be reserved word: GRANT
 
 CREATE TABLE GROUP (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: GROUP
+-- error 42601: syntax error: table name cannot be reserved word: GROUP
 
 CREATE TABLE GROUPING (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: GROUPING
+-- error 42601: syntax error: table name cannot be reserved word: GROUPING
 
 CREATE TABLE GROUPS (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: GROUPS
+-- error 42601: syntax error: table name cannot be reserved word: GROUPS
 
 CREATE TABLE HAVING (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: HAVING
+-- error 42601: syntax error: table name cannot be reserved word: HAVING
 
 CREATE TABLE HOLD (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: HOLD
+-- error 42601: syntax error: table name cannot be reserved word: HOLD
 
 CREATE TABLE HOUR (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: HOUR
+-- error 42601: syntax error: table name cannot be reserved word: HOUR
 
 CREATE TABLE IDENTITY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: IDENTITY
+-- error 42601: syntax error: table name cannot be reserved word: IDENTITY
 
 CREATE TABLE IN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: IN
+-- error 42601: syntax error: table name cannot be reserved word: IN
 
 CREATE TABLE INDICATOR (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: INDICATOR
+-- error 42601: syntax error: table name cannot be reserved word: INDICATOR
 
 CREATE TABLE INITIAL (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: INITIAL
+-- error 42601: syntax error: table name cannot be reserved word: INITIAL
 
 CREATE TABLE INNER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: INNER
+-- error 42601: syntax error: table name cannot be reserved word: INNER
 
 CREATE TABLE INOUT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: INOUT
+-- error 42601: syntax error: table name cannot be reserved word: INOUT
 
 CREATE TABLE INSENSITIVE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: INSENSITIVE
+-- error 42601: syntax error: table name cannot be reserved word: INSENSITIVE
 
 CREATE TABLE INSERT (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found INSERT
+-- error 42601: syntax error: expecting literal_identifier but found INSERT
 
 CREATE TABLE INT (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found INT
+-- error 42601: syntax error: expecting literal_identifier but found INT
 
 CREATE TABLE INTEGER (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found INTEGER
+-- error 42601: syntax error: expecting literal_identifier but found INTEGER
 
 CREATE TABLE INTERSECT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: INTERSECT
+-- error 42601: syntax error: table name cannot be reserved word: INTERSECT
 
 CREATE TABLE INTERSECTION (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: INTERSECTION
+-- error 42601: syntax error: table name cannot be reserved word: INTERSECTION
 
 CREATE TABLE INTERVAL (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: INTERVAL
+-- error 42601: syntax error: table name cannot be reserved word: INTERVAL
 
 CREATE TABLE INTO (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found INTO
+-- error 42601: syntax error: expecting literal_identifier but found INTO
 
 CREATE TABLE IS (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found IS
+-- error 42601: syntax error: expecting literal_identifier but found IS
 
 CREATE TABLE JOIN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: JOIN
+-- error 42601: syntax error: table name cannot be reserved word: JOIN
 
 CREATE TABLE JSON_ARRAY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: JSON_ARRAY
+-- error 42601: syntax error: table name cannot be reserved word: JSON_ARRAY
 
 CREATE TABLE JSON_ARRAYAGG (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: JSON_ARRAYAGG
+-- error 42601: syntax error: table name cannot be reserved word: JSON_ARRAYAGG
 
 CREATE TABLE JSON_EXISTS (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: JSON_EXISTS
+-- error 42601: syntax error: table name cannot be reserved word: JSON_EXISTS
 
 CREATE TABLE JSON_OBJECT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: JSON_OBJECT
+-- error 42601: syntax error: table name cannot be reserved word: JSON_OBJECT
 
 CREATE TABLE JSON_OBJECTAGG (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: JSON_OBJECTAGG
+-- error 42601: syntax error: table name cannot be reserved word: JSON_OBJECTAGG
 
 CREATE TABLE JSON_QUERY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: JSON_QUERY
+-- error 42601: syntax error: table name cannot be reserved word: JSON_QUERY
 
 CREATE TABLE JSON_TABLE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: JSON_TABLE
+-- error 42601: syntax error: table name cannot be reserved word: JSON_TABLE
 
 CREATE TABLE JSON_TABLE_PRIMITIVE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: JSON_TABLE_PRIMITIVE
+-- error 42601: syntax error: table name cannot be reserved word: JSON_TABLE_PRIMITIVE
 
 CREATE TABLE JSON_VALUE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: JSON_VALUE
+-- error 42601: syntax error: table name cannot be reserved word: JSON_VALUE
 
 CREATE TABLE LAG (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LAG
+-- error 42601: syntax error: table name cannot be reserved word: LAG
 
 CREATE TABLE LANGUAGE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LANGUAGE
+-- error 42601: syntax error: table name cannot be reserved word: LANGUAGE
 
 CREATE TABLE LARGE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LARGE
+-- error 42601: syntax error: table name cannot be reserved word: LARGE
 
 CREATE TABLE LAST_VALUE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LAST_VALUE
+-- error 42601: syntax error: table name cannot be reserved word: LAST_VALUE
 
 CREATE TABLE LATERAL (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LATERAL
+-- error 42601: syntax error: table name cannot be reserved word: LATERAL
 
 CREATE TABLE LEAD (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LEAD
+-- error 42601: syntax error: table name cannot be reserved word: LEAD
 
 CREATE TABLE LEADING (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LEADING
+-- error 42601: syntax error: table name cannot be reserved word: LEADING
 
 CREATE TABLE LEFT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LEFT
+-- error 42601: syntax error: table name cannot be reserved word: LEFT
 
 CREATE TABLE LIKE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LIKE
+-- error 42601: syntax error: table name cannot be reserved word: LIKE
 
 CREATE TABLE LIKE_REGEX (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LIKE_REGEX
+-- error 42601: syntax error: table name cannot be reserved word: LIKE_REGEX
 
 CREATE TABLE LISTAGG (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LISTAGG
+-- error 42601: syntax error: table name cannot be reserved word: LISTAGG
 
 CREATE TABLE LN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LN
+-- error 42601: syntax error: table name cannot be reserved word: LN
 
 CREATE TABLE LOCAL (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LOCAL
+-- error 42601: syntax error: table name cannot be reserved word: LOCAL
 
 CREATE TABLE LOCALTIME (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LOCALTIME
+-- error 42601: syntax error: table name cannot be reserved word: LOCALTIME
 
 CREATE TABLE LOCALTIMESTAMP (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LOCALTIMESTAMP
+-- error 42601: syntax error: table name cannot be reserved word: LOCALTIMESTAMP
 
 CREATE TABLE LOG (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LOG
+-- error 42601: syntax error: table name cannot be reserved word: LOG
 
 CREATE TABLE LOG10 (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LOG10
+-- error 42601: syntax error: table name cannot be reserved word: LOG10
 
 CREATE TABLE LOWER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: LOWER
+-- error 42601: syntax error: table name cannot be reserved word: LOWER
 
 CREATE TABLE MATCH (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: MATCH
+-- error 42601: syntax error: table name cannot be reserved word: MATCH
 
 CREATE TABLE MATCH_NUMBER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: MATCH_NUMBER
+-- error 42601: syntax error: table name cannot be reserved word: MATCH_NUMBER
 
 CREATE TABLE MATCH_RECOGNIZE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: MATCH_RECOGNIZE
+-- error 42601: syntax error: table name cannot be reserved word: MATCH_RECOGNIZE
 
 CREATE TABLE MATCHES (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: MATCHES
+-- error 42601: syntax error: table name cannot be reserved word: MATCHES
 
 CREATE TABLE MAX (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: MAX
+-- error 42601: syntax error: table name cannot be reserved word: MAX
 
 CREATE TABLE MEMBER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: MEMBER
+-- error 42601: syntax error: table name cannot be reserved word: MEMBER
 
 CREATE TABLE MERGE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: MERGE
+-- error 42601: syntax error: table name cannot be reserved word: MERGE
 
 CREATE TABLE METHOD (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: METHOD
+-- error 42601: syntax error: table name cannot be reserved word: METHOD
 
 CREATE TABLE MIN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: MIN
+-- error 42601: syntax error: table name cannot be reserved word: MIN
 
 CREATE TABLE MINUTE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: MINUTE
+-- error 42601: syntax error: table name cannot be reserved word: MINUTE
 
 CREATE TABLE MOD (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: MOD
+-- error 42601: syntax error: table name cannot be reserved word: MOD
 
 CREATE TABLE MODIFIES (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: MODIFIES
+-- error 42601: syntax error: table name cannot be reserved word: MODIFIES
 
 CREATE TABLE MODULE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: MODULE
+-- error 42601: syntax error: table name cannot be reserved word: MODULE
 
 CREATE TABLE MONTH (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: MONTH
+-- error 42601: syntax error: table name cannot be reserved word: MONTH
 
 CREATE TABLE MULTISET (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: MULTISET
+-- error 42601: syntax error: table name cannot be reserved word: MULTISET
 
 CREATE TABLE NATIONAL (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: NATIONAL
+-- error 42601: syntax error: table name cannot be reserved word: NATIONAL
 
 CREATE TABLE NATURAL (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: NATURAL
+-- error 42601: syntax error: table name cannot be reserved word: NATURAL
 
 CREATE TABLE NCHAR (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: NCHAR
+-- error 42601: syntax error: table name cannot be reserved word: NCHAR
 
 CREATE TABLE NCLOB (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: NCLOB
+-- error 42601: syntax error: table name cannot be reserved word: NCLOB
 
 CREATE TABLE NEW (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: NEW
+-- error 42601: syntax error: table name cannot be reserved word: NEW
 
 CREATE TABLE NO (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: NO
+-- error 42601: syntax error: table name cannot be reserved word: NO
 
 CREATE TABLE NONE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: NONE
+-- error 42601: syntax error: table name cannot be reserved word: NONE
 
 CREATE TABLE NORMALIZE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: NORMALIZE
+-- error 42601: syntax error: table name cannot be reserved word: NORMALIZE
 
 CREATE TABLE NOT (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found NOT
+-- error 42601: syntax error: expecting literal_identifier but found NOT
 
 CREATE TABLE NTH_VALUE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: NTH_VALUE
+-- error 42601: syntax error: table name cannot be reserved word: NTH_VALUE
 
 CREATE TABLE NTILE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: NTILE
+-- error 42601: syntax error: table name cannot be reserved word: NTILE
 
 CREATE TABLE NULL (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found NULL
+-- error 42601: syntax error: expecting literal_identifier but found NULL
 
 CREATE TABLE NULLIF (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: NULLIF
+-- error 42601: syntax error: table name cannot be reserved word: NULLIF
 
 CREATE TABLE NUMERIC (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: NUMERIC
+-- error 42601: syntax error: table name cannot be reserved word: NUMERIC
 
 CREATE TABLE OCTET_LENGTH (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: OCTET_LENGTH
+-- error 42601: syntax error: table name cannot be reserved word: OCTET_LENGTH
 
 CREATE TABLE OCCURRENCES_REGEX (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: OCCURRENCES_REGEX
+-- error 42601: syntax error: table name cannot be reserved word: OCCURRENCES_REGEX
 
 CREATE TABLE OF (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: OF
+-- error 42601: syntax error: table name cannot be reserved word: OF
 
 CREATE TABLE OFFSET (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: OFFSET
+-- error 42601: syntax error: table name cannot be reserved word: OFFSET
 
 CREATE TABLE OLD (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: OLD
+-- error 42601: syntax error: table name cannot be reserved word: OLD
 
 CREATE TABLE OMIT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: OMIT
+-- error 42601: syntax error: table name cannot be reserved word: OMIT
 
 CREATE TABLE ON (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ON
+-- error 42601: syntax error: table name cannot be reserved word: ON
 
 CREATE TABLE ONE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ONE
+-- error 42601: syntax error: table name cannot be reserved word: ONE
 
 CREATE TABLE ONLY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ONLY
+-- error 42601: syntax error: table name cannot be reserved word: ONLY
 
 CREATE TABLE OPEN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: OPEN
+-- error 42601: syntax error: table name cannot be reserved word: OPEN
 
 CREATE TABLE OR (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: OR
+-- error 42601: syntax error: table name cannot be reserved word: OR
 
 CREATE TABLE ORDER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ORDER
+-- error 42601: syntax error: table name cannot be reserved word: ORDER
 
 CREATE TABLE OUT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: OUT
+-- error 42601: syntax error: table name cannot be reserved word: OUT
 
 CREATE TABLE OUTER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: OUTER
+-- error 42601: syntax error: table name cannot be reserved word: OUTER
 
 CREATE TABLE OVER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: OVER
+-- error 42601: syntax error: table name cannot be reserved word: OVER
 
 CREATE TABLE OVERLAPS (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: OVERLAPS
+-- error 42601: syntax error: table name cannot be reserved word: OVERLAPS
 
 CREATE TABLE OVERLAY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: OVERLAY
+-- error 42601: syntax error: table name cannot be reserved word: OVERLAY
 
 CREATE TABLE PARAMETER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: PARAMETER
+-- error 42601: syntax error: table name cannot be reserved word: PARAMETER
 
 CREATE TABLE PARTITION (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: PARTITION
+-- error 42601: syntax error: table name cannot be reserved word: PARTITION
 
 CREATE TABLE PATTERN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: PATTERN
+-- error 42601: syntax error: table name cannot be reserved word: PATTERN
 
 CREATE TABLE PER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: PER
+-- error 42601: syntax error: table name cannot be reserved word: PER
 
 CREATE TABLE PERCENT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: PERCENT
+-- error 42601: syntax error: table name cannot be reserved word: PERCENT
 
 CREATE TABLE PERCENT_RANK (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: PERCENT_RANK
+-- error 42601: syntax error: table name cannot be reserved word: PERCENT_RANK
 
 CREATE TABLE PERCENTILE_CONT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: PERCENTILE_CONT
+-- error 42601: syntax error: table name cannot be reserved word: PERCENTILE_CONT
 
 CREATE TABLE PERCENTILE_DISC (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: PERCENTILE_DISC
+-- error 42601: syntax error: table name cannot be reserved word: PERCENTILE_DISC
 
 CREATE TABLE PERIOD (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: PERIOD
+-- error 42601: syntax error: table name cannot be reserved word: PERIOD
 
 CREATE TABLE PORTION (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: PORTION
+-- error 42601: syntax error: table name cannot be reserved word: PORTION
 
 CREATE TABLE POSITION (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: POSITION
+-- error 42601: syntax error: table name cannot be reserved word: POSITION
 
 CREATE TABLE POSITION_REGEX (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: POSITION_REGEX
+-- error 42601: syntax error: table name cannot be reserved word: POSITION_REGEX
 
 CREATE TABLE POWER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: POWER
+-- error 42601: syntax error: table name cannot be reserved word: POWER
 
 CREATE TABLE PRECEDES (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: PRECEDES
+-- error 42601: syntax error: table name cannot be reserved word: PRECEDES
 
 CREATE TABLE PRECISION (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found PRECISION
+-- error 42601: syntax error: expecting literal_identifier but found PRECISION
 
 CREATE TABLE PREPARE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: PREPARE
+-- error 42601: syntax error: table name cannot be reserved word: PREPARE
 
 CREATE TABLE PRIMARY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: PRIMARY
+-- error 42601: syntax error: table name cannot be reserved word: PRIMARY
 
 CREATE TABLE PROCEDURE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: PROCEDURE
+-- error 42601: syntax error: table name cannot be reserved word: PROCEDURE
 
 CREATE TABLE PTF (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: PTF
+-- error 42601: syntax error: table name cannot be reserved word: PTF
 
 CREATE TABLE RANGE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: RANGE
+-- error 42601: syntax error: table name cannot be reserved word: RANGE
 
 CREATE TABLE RANK (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: RANK
+-- error 42601: syntax error: table name cannot be reserved word: RANK
 
 CREATE TABLE READS (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: READS
+-- error 42601: syntax error: table name cannot be reserved word: READS
 
 CREATE TABLE REAL (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found REAL
+-- error 42601: syntax error: expecting literal_identifier but found REAL
 
 CREATE TABLE RECURSIVE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: RECURSIVE
+-- error 42601: syntax error: table name cannot be reserved word: RECURSIVE
 
 CREATE TABLE REF (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: REF
+-- error 42601: syntax error: table name cannot be reserved word: REF
 
 CREATE TABLE REFERENCES (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: REFERENCES
+-- error 42601: syntax error: table name cannot be reserved word: REFERENCES
 
 CREATE TABLE REFERENCING (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: REFERENCING
+-- error 42601: syntax error: table name cannot be reserved word: REFERENCING
 
 CREATE TABLE REGR_AVGX (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: REGR_AVGX
+-- error 42601: syntax error: table name cannot be reserved word: REGR_AVGX
 
 CREATE TABLE REGR_AVGY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: REGR_AVGY
+-- error 42601: syntax error: table name cannot be reserved word: REGR_AVGY
 
 CREATE TABLE REGR_COUNT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: REGR_COUNT
+-- error 42601: syntax error: table name cannot be reserved word: REGR_COUNT
 
 CREATE TABLE REGR_INTERCEPT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: REGR_INTERCEPT
+-- error 42601: syntax error: table name cannot be reserved word: REGR_INTERCEPT
 
 CREATE TABLE REGR_R2 (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: REGR_R2
+-- error 42601: syntax error: table name cannot be reserved word: REGR_R2
 
 CREATE TABLE REGR_SLOPE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: REGR_SLOPE
+-- error 42601: syntax error: table name cannot be reserved word: REGR_SLOPE
 
 CREATE TABLE REGR_SXX (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: REGR_SXX
+-- error 42601: syntax error: table name cannot be reserved word: REGR_SXX
 
 CREATE TABLE REGR_SXY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: REGR_SXY
+-- error 42601: syntax error: table name cannot be reserved word: REGR_SXY
 
 CREATE TABLE REGR_SYY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: REGR_SYY
+-- error 42601: syntax error: table name cannot be reserved word: REGR_SYY
 
 CREATE TABLE RELEASE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: RELEASE
+-- error 42601: syntax error: table name cannot be reserved word: RELEASE
 
 CREATE TABLE RESULT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: RESULT
+-- error 42601: syntax error: table name cannot be reserved word: RESULT
 
 CREATE TABLE RETURN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: RETURN
+-- error 42601: syntax error: table name cannot be reserved word: RETURN
 
 CREATE TABLE RETURNS (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: RETURNS
+-- error 42601: syntax error: table name cannot be reserved word: RETURNS
 
 CREATE TABLE REVOKE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: REVOKE
+-- error 42601: syntax error: table name cannot be reserved word: REVOKE
 
 CREATE TABLE RIGHT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: RIGHT
+-- error 42601: syntax error: table name cannot be reserved word: RIGHT
 
 CREATE TABLE ROLLBACK (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ROLLBACK
+-- error 42601: syntax error: table name cannot be reserved word: ROLLBACK
 
 CREATE TABLE ROLLUP (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ROLLUP
+-- error 42601: syntax error: table name cannot be reserved word: ROLLUP
 
 CREATE TABLE ROW (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ROW
+-- error 42601: syntax error: table name cannot be reserved word: ROW
 
 CREATE TABLE ROW_NUMBER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ROW_NUMBER
+-- error 42601: syntax error: table name cannot be reserved word: ROW_NUMBER
 
 CREATE TABLE ROWS (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ROWS
+-- error 42601: syntax error: table name cannot be reserved word: ROWS
 
 CREATE TABLE RUNNING (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: RUNNING
+-- error 42601: syntax error: table name cannot be reserved word: RUNNING
 
 CREATE TABLE SAVEPOINT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SAVEPOINT
+-- error 42601: syntax error: table name cannot be reserved word: SAVEPOINT
 
 CREATE TABLE SCOPE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SCOPE
+-- error 42601: syntax error: table name cannot be reserved word: SCOPE
 
 CREATE TABLE SCROLL (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SCROLL
+-- error 42601: syntax error: table name cannot be reserved word: SCROLL
 
 CREATE TABLE SEARCH (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SEARCH
+-- error 42601: syntax error: table name cannot be reserved word: SEARCH
 
 CREATE TABLE SECOND (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SECOND
+-- error 42601: syntax error: table name cannot be reserved word: SECOND
 
 CREATE TABLE SEEK (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SEEK
+-- error 42601: syntax error: table name cannot be reserved word: SEEK
 
 CREATE TABLE SELECT (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found SELECT
+-- error 42601: syntax error: expecting literal_identifier but found SELECT
 
 CREATE TABLE SENSITIVE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SENSITIVE
+-- error 42601: syntax error: table name cannot be reserved word: SENSITIVE
 
 CREATE TABLE SESSION_USER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SESSION_USER
+-- error 42601: syntax error: table name cannot be reserved word: SESSION_USER
 
 CREATE TABLE SET (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found SET
+-- error 42601: syntax error: expecting literal_identifier but found SET
 
 CREATE TABLE SHOW (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SHOW
+-- error 42601: syntax error: table name cannot be reserved word: SHOW
 
 CREATE TABLE SIMILAR (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SIMILAR
+-- error 42601: syntax error: table name cannot be reserved word: SIMILAR
 
 CREATE TABLE SIN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SIN
+-- error 42601: syntax error: table name cannot be reserved word: SIN
 
 CREATE TABLE SINH (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SINH
+-- error 42601: syntax error: table name cannot be reserved word: SINH
 
 CREATE TABLE SKIP (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SKIP
+-- error 42601: syntax error: table name cannot be reserved word: SKIP
 
 CREATE TABLE SMALLINT (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found SMALLINT
+-- error 42601: syntax error: expecting literal_identifier but found SMALLINT
 
 CREATE TABLE SOME (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SOME
+-- error 42601: syntax error: table name cannot be reserved word: SOME
 
 CREATE TABLE SPECIFIC (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SPECIFIC
+-- error 42601: syntax error: table name cannot be reserved word: SPECIFIC
 
 CREATE TABLE SPECIFICTYPE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SPECIFICTYPE
+-- error 42601: syntax error: table name cannot be reserved word: SPECIFICTYPE
 
 CREATE TABLE SQL (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SQL
+-- error 42601: syntax error: table name cannot be reserved word: SQL
 
 CREATE TABLE SQLEXCEPTION (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SQLEXCEPTION
+-- error 42601: syntax error: table name cannot be reserved word: SQLEXCEPTION
 
 CREATE TABLE SQLSTATE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SQLSTATE
+-- error 42601: syntax error: table name cannot be reserved word: SQLSTATE
 
 CREATE TABLE SQLWARNING (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SQLWARNING
+-- error 42601: syntax error: table name cannot be reserved word: SQLWARNING
 
 CREATE TABLE SQRT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SQRT
+-- error 42601: syntax error: table name cannot be reserved word: SQRT
 
 CREATE TABLE START (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: START
+-- error 42601: syntax error: table name cannot be reserved word: START
 
 CREATE TABLE STATIC (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: STATIC
+-- error 42601: syntax error: table name cannot be reserved word: STATIC
 
 CREATE TABLE STDDEV_POP (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: STDDEV_POP
+-- error 42601: syntax error: table name cannot be reserved word: STDDEV_POP
 
 CREATE TABLE STDDEV_SAMP (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: STDDEV_SAMP
+-- error 42601: syntax error: table name cannot be reserved word: STDDEV_SAMP
 
 CREATE TABLE SUBMULTISET (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SUBMULTISET
+-- error 42601: syntax error: table name cannot be reserved word: SUBMULTISET
 
 CREATE TABLE SUBSET (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SUBSET
+-- error 42601: syntax error: table name cannot be reserved word: SUBSET
 
 CREATE TABLE SUBSTRING (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SUBSTRING
+-- error 42601: syntax error: table name cannot be reserved word: SUBSTRING
 
 CREATE TABLE SUBSTRING_REGEX (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SUBSTRING_REGEX
+-- error 42601: syntax error: table name cannot be reserved word: SUBSTRING_REGEX
 
 CREATE TABLE SUCCEEDS (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SUCCEEDS
+-- error 42601: syntax error: table name cannot be reserved word: SUCCEEDS
 
 CREATE TABLE SUM (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SUM
+-- error 42601: syntax error: table name cannot be reserved word: SUM
 
 CREATE TABLE SYMMETRIC (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SYMMETRIC
+-- error 42601: syntax error: table name cannot be reserved word: SYMMETRIC
 
 CREATE TABLE SYSTEM (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SYSTEM
+-- error 42601: syntax error: table name cannot be reserved word: SYSTEM
 
 CREATE TABLE SYSTEM_TIME (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SYSTEM_TIME
+-- error 42601: syntax error: table name cannot be reserved word: SYSTEM_TIME
 
 CREATE TABLE SYSTEM_USER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: SYSTEM_USER
+-- error 42601: syntax error: table name cannot be reserved word: SYSTEM_USER
 
 CREATE TABLE TABLE (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found TABLE
+-- error 42601: syntax error: expecting literal_identifier but found TABLE
 
 CREATE TABLE TABLESAMPLE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TABLESAMPLE
+-- error 42601: syntax error: table name cannot be reserved word: TABLESAMPLE
 
 CREATE TABLE TAN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TAN
+-- error 42601: syntax error: table name cannot be reserved word: TAN
 
 CREATE TABLE TANH (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TANH
+-- error 42601: syntax error: table name cannot be reserved word: TANH
 
 CREATE TABLE THEN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: THEN
+-- error 42601: syntax error: table name cannot be reserved word: THEN
 
 CREATE TABLE TIME (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TIME
+-- error 42601: syntax error: table name cannot be reserved word: TIME
 
 CREATE TABLE TIMESTAMP (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TIMESTAMP
+-- error 42601: syntax error: table name cannot be reserved word: TIMESTAMP
 
 CREATE TABLE TIMEZONE_HOUR (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TIMEZONE_HOUR
+-- error 42601: syntax error: table name cannot be reserved word: TIMEZONE_HOUR
 
 CREATE TABLE TIMEZONE_MINUTE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TIMEZONE_MINUTE
+-- error 42601: syntax error: table name cannot be reserved word: TIMEZONE_MINUTE
 
 CREATE TABLE TO (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TO
+-- error 42601: syntax error: table name cannot be reserved word: TO
 
 CREATE TABLE TRAILING (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TRAILING
+-- error 42601: syntax error: table name cannot be reserved word: TRAILING
 
 CREATE TABLE TRANSLATE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TRANSLATE
+-- error 42601: syntax error: table name cannot be reserved word: TRANSLATE
 
 CREATE TABLE TRANSLATE_REGEX (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TRANSLATE_REGEX
+-- error 42601: syntax error: table name cannot be reserved word: TRANSLATE_REGEX
 
 CREATE TABLE TRANSLATION (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TRANSLATION
+-- error 42601: syntax error: table name cannot be reserved word: TRANSLATION
 
 CREATE TABLE TREAT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TREAT
+-- error 42601: syntax error: table name cannot be reserved word: TREAT
 
 CREATE TABLE TRIGGER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TRIGGER
+-- error 42601: syntax error: table name cannot be reserved word: TRIGGER
 
 CREATE TABLE TRIM (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TRIM
+-- error 42601: syntax error: table name cannot be reserved word: TRIM
 
 CREATE TABLE TRIM_ARRAY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TRIM_ARRAY
+-- error 42601: syntax error: table name cannot be reserved word: TRIM_ARRAY
 
 CREATE TABLE TRUE (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found TRUE
+-- error 42601: syntax error: expecting literal_identifier but found TRUE
 
 CREATE TABLE TRUNCATE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: TRUNCATE
+-- error 42601: syntax error: table name cannot be reserved word: TRUNCATE
 
 CREATE TABLE UESCAPE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: UESCAPE
+-- error 42601: syntax error: table name cannot be reserved word: UESCAPE
 
 CREATE TABLE UNION (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: UNION
+-- error 42601: syntax error: table name cannot be reserved word: UNION
 
 CREATE TABLE UNIQUE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: UNIQUE
+-- error 42601: syntax error: table name cannot be reserved word: UNIQUE
 
 CREATE TABLE UNKNOWN (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found UNKNOWN
+-- error 42601: syntax error: expecting literal_identifier but found UNKNOWN
 
 CREATE TABLE UNNEST (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: UNNEST
+-- error 42601: syntax error: table name cannot be reserved word: UNNEST
 
 CREATE TABLE UPDATE (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found UPDATE
+-- error 42601: syntax error: expecting literal_identifier but found UPDATE
 
 CREATE TABLE UPPER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: UPPER
+-- error 42601: syntax error: table name cannot be reserved word: UPPER
 
 CREATE TABLE USER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: USER
+-- error 42601: syntax error: table name cannot be reserved word: USER
 
 CREATE TABLE USING (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: USING
+-- error 42601: syntax error: table name cannot be reserved word: USING
 
 CREATE TABLE VALUE (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: VALUE
+-- error 42601: syntax error: table name cannot be reserved word: VALUE
 
 CREATE TABLE VALUES (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found VALUES
+-- error 42601: syntax error: expecting literal_identifier but found VALUES
 
 CREATE TABLE VALUE_OF (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: VALUE_OF
+-- error 42601: syntax error: table name cannot be reserved word: VALUE_OF
 
 CREATE TABLE VAR_POP (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: VAR_POP
+-- error 42601: syntax error: table name cannot be reserved word: VAR_POP
 
 CREATE TABLE VAR_SAMP (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: VAR_SAMP
+-- error 42601: syntax error: table name cannot be reserved word: VAR_SAMP
 
 CREATE TABLE VARBINARY (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: VARBINARY
+-- error 42601: syntax error: table name cannot be reserved word: VARBINARY
 
 CREATE TABLE VARCHAR (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found VARCHAR
+-- error 42601: syntax error: expecting literal_identifier but found VARCHAR
 
 CREATE TABLE VARYING (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found VARYING
+-- error 42601: syntax error: expecting literal_identifier but found VARYING
 
 CREATE TABLE VERSIONING (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: VERSIONING
+-- error 42601: syntax error: table name cannot be reserved word: VERSIONING
 
 CREATE TABLE WHEN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: WHEN
+-- error 42601: syntax error: table name cannot be reserved word: WHEN
 
 CREATE TABLE WHENEVER (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: WHENEVER
+-- error 42601: syntax error: table name cannot be reserved word: WHENEVER
 
 CREATE TABLE WHERE (a INT)
--- error: vsql.SQLState42601: syntax error: expecting literal_identifier but found WHERE
+-- error 42601: syntax error: expecting literal_identifier but found WHERE
 
 CREATE TABLE WIDTH_BUCKET (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: WIDTH_BUCKET
+-- error 42601: syntax error: table name cannot be reserved word: WIDTH_BUCKET
 
 CREATE TABLE WINDOW (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: WINDOW
+-- error 42601: syntax error: table name cannot be reserved word: WINDOW
 
 CREATE TABLE WITH (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: WITH
+-- error 42601: syntax error: table name cannot be reserved word: WITH
 
 CREATE TABLE WITHIN (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: WITHIN
+-- error 42601: syntax error: table name cannot be reserved word: WITHIN
 
 CREATE TABLE WITHOUT (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: WITHOUT
+-- error 42601: syntax error: table name cannot be reserved word: WITHOUT
 
 CREATE TABLE YEAR (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: YEAR
+-- error 42601: syntax error: table name cannot be reserved word: YEAR
 
 CREATE TABLE abs (a INT)
--- error: vsql.SQLState42601: syntax error: table name cannot be reserved word: ABS
+-- error 42601: syntax error: table name cannot be reserved word: ABS
 
 CREATE TABLE foo (ABS INT)
--- error: vsql.SQLState42601: syntax error: column name cannot be reserved word: ABS
+-- error 42601: syntax error: column name cannot be reserved word: ABS
 
 CREATE TABLE foo (abs int)
--- error: vsql.SQLState42601: syntax error: column name cannot be reserved word: ABS
+-- error 42601: syntax error: column name cannot be reserved word: ABS

--- a/tests/select-from.sql
+++ b/tests/select-from.sql
@@ -1,5 +1,5 @@
 SELECT * FROM foo
--- error: vsql.SQLState42P01: no such table: FOO
+-- error 42P01: no such table: FOO
 
 CREATE TABLE foo (a FLOAT)
 INSERT INTO foo (a) VALUES (1.234)

--- a/tests/update.sql
+++ b/tests/update.sql
@@ -1,5 +1,5 @@
 UPDATE foo SET a = 123
--- error: vsql.SQLState42P01: no such table: FOO
+-- error 42P01: no such table: FOO
 
 CREATE TABLE foo (baz CHARACTER VARYING(10))
 INSERT INTO foo (baz) VALUES ('hi')
@@ -32,7 +32,7 @@ SELECT * FROM foo
 CREATE TABLE foo (baz FLOAT)
 UPDATE foo SET baz = true
 -- msg: CREATE TABLE 1
--- error: vsql.SQLState42804: data type mismatch for column BAZ: expected FLOAT but got BOOLEAN
+-- error 42804: data type mismatch for column BAZ: expected FLOAT but got BOOLEAN
 
 CREATE TABLE foo (baz FLOAT)
 INSERT INTO foo (baz) VALUES (123)
@@ -48,4 +48,4 @@ INSERT INTO foo (baz) VALUES (123)
 UPDATE foo SET baz = NULL
 -- msg: CREATE TABLE 1
 -- msg: INSERT 1
--- error: vsql.SQLState42804: violates non-null constraint: column BAZ
+-- error 23502: violates non-null constraint: column BAZ

--- a/vsql/sql_test.v
+++ b/vsql/sql_test.v
@@ -52,7 +52,7 @@ fn test_all() ? {
 		mut actual := ''
 		for stmt in test.stmts {
 			result := db.query(stmt) or {
-				actual += 'error: $err\n'
+				actual += 'error ${sqlstate_from_int(err.code)}: $err.msg\n'
 				continue
 			}
 

--- a/vsql/sqlstate.v
+++ b/vsql/sqlstate.v
@@ -7,6 +7,50 @@
 
 module vsql
 
+// sqlstate_to_int converts the 5 character SQLSTATE code (such as "42P01") into
+// an integer representation. The returned value can be converted back to its
+// respective string by using sqlstate_from_int().
+//
+// If code is invalid the result will be unexpected.
+pub fn sqlstate_to_int(code string) int {
+	upper_code := code.to_upper()
+
+	return sqlstate_chr(upper_code[0]) * 1679616 + sqlstate_chr(upper_code[1]) * 46656 +
+		sqlstate_chr(upper_code[2]) * 1296 + sqlstate_chr(upper_code[3]) * 36 +
+		sqlstate_chr(upper_code[4])
+}
+
+fn sqlstate_chr(ch byte) int {
+	if ch <= `9` {
+		return ch - byte(`0`)
+	}
+
+	return ch - byte(`A`) + 10
+}
+
+fn sqlstate_ord(ch int) byte {
+	if ch <= 9 {
+		return byte(byte(`0`) + ch)
+	}
+
+	return byte(byte(`A`) + (ch - 10))
+}
+
+pub fn sqlstate_from_int(code int) string {
+	mut b := []byte{len: 5}
+
+	mut i := 0
+	mut left := code
+	for m in [1679616, 46656, 1296, 36, 1] {
+		x := int(left / m)
+		b[i] = sqlstate_ord(x)
+		left -= x * m
+		i++
+	}
+
+	return string(b)
+}
+
 // violates non-null constraint
 struct SQLState23502 {
 	msg  string
@@ -15,6 +59,7 @@ struct SQLState23502 {
 
 fn sqlstate_23502(msg string) IError {
 	return SQLState42804{
+		code: sqlstate_to_int('23502')
 		msg: 'violates non-null constraint: $msg'
 	}
 }
@@ -27,6 +72,7 @@ struct SQLState42601 {
 
 fn sqlstate_42601(message string) IError {
 	return SQLState42601{
+		code: sqlstate_to_int('42601')
 		msg: 'syntax error: $message'
 	}
 }
@@ -41,6 +87,7 @@ pub:
 
 fn sqlstate_42703(column_name string) IError {
 	return SQLState42703{
+		code: sqlstate_to_int('42703')
 		msg: 'no such column: $column_name'
 		column_name: column_name
 	}
@@ -56,6 +103,7 @@ struct SQLState42804 {
 
 fn sqlstate_42804(msg string, expected string, actual string) IError {
 	return SQLState42804{
+		code: sqlstate_to_int('42804')
 		msg: 'data type mismatch $msg: expected $expected but got $actual'
 		expected: expected
 		actual: actual
@@ -72,6 +120,7 @@ pub:
 
 fn sqlstate_42p01(table_name string) IError {
 	return SQLState42P01{
+		code: sqlstate_to_int('42P01')
 		msg: 'no such table: $table_name'
 		table_name: table_name
 	}
@@ -87,6 +136,7 @@ pub:
 
 fn sqlstate_42p07(table_name string) IError {
 	return SQLState42P07{
+		code: sqlstate_to_int('42P07')
 		msg: 'duplicate table: $table_name'
 		table_name: table_name
 	}


### PR DESCRIPTION
The SQLState structs now carry the SQLSTATE in their `code` attribute.
Along with the new functions `sqlstate_from_int()` and
`sqlstate_to_int()` more flexible printing and matching operations are
possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/11)
<!-- Reviewable:end -->
