### PR TITLE
Produce binaries for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,52 @@ on:
 jobs:
   run:
     name: Run
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
     - name: Set up V version latest
       uses: nocturlab/setup-vlang-action@v1
       with:
         v-version: master
       id: v
+
     - name: Verify fmt
       run: v fmt -verify .
+
     - name: Run SQL tests
       run: v -stats -prod test vsql
+
+    - name: Prepare version
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+    - name: Build macOS binaries
+      run: |
+        v -prod vsql-cli.v
+        v -prod vsql-server.v
+        zip vsql-$RELEASE_VERSION-macos.zip vsql-cli vsql-server
+    # See https://github.com/vlang/v/issues/10992
+    #- name: Build linux binaries
+    #  run: |
+    #    v -os linux -prod vsql-cli.v
+    #    v -os linux -prod vsql-server.v
+    #    zip vsql-$RELEASE_VERSION-linux.zip vsql-cli vsql-server
+
+    # Cross compiling for windows takes a long time because mingw-w64 has to be
+    # installed. So we only run this when we're doing a release.
+    - name: Build windows binaries
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        brew install mingw-w64
+        v -os windows -prod vsql-cli.v
+        v -os windows -prod vsql-server.v
+        zip vsql-$RELEASE_VERSION-windows.zip vsql-cli.exe vsql-server.exe
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+          vsql-$RELEASE_VERSION-macos.zip
+          vsql-$RELEASE_VERSION-windows.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/.DS_Store
 vsql-cli
+vsql-server
 *.vsql

--- a/vsql-server.v
+++ b/vsql-server.v
@@ -135,7 +135,7 @@ fn write_command_complete(client_id int, mut conn net.TcpConn, result vsql.Resul
 	// TODO(elliotchance): This is a hack that will probably cause issues.
 	mut tag := 'SELECT $result.rows.len'
 	if result.columns == ['msg'] && result.rows.len == 1 {
-		tag = result.rows[0].get_string('msg')
+		tag = result.rows[0].get_string('msg') or { '$err' }
 	}
 
 	mut msg_len := 4 // self
@@ -220,7 +220,7 @@ fn write_data_row(mut conn net.TcpConn, columns []string, row vsql.Row) {
 	mut msg_len := 4 // self
 	msg_len += 2 // cols
 	for column in columns {
-		v := row.get_string(column)
+		v := row.get_string(column) or { '$err' }
 		msg_len += 4 + v.len
 	}
 
@@ -228,7 +228,7 @@ fn write_data_row(mut conn net.TcpConn, columns []string, row vsql.Row) {
 	write_int16(mut conn, i16(columns.len))
 
 	for column in columns {
-		v := row.get_string(column)
+		v := row.get_string(column) or { '$err' }
 		write_int32(mut conn, v.len)
 		write_bytes(mut conn, v.bytes())
 	}


### PR DESCRIPTION

A zip file containing the standalone vsql-cli and vsql-server can be
downloaded from the Github Releases page to use vsql without needing a
V compilication environment.

At the moment only macOS and windows binaries are produced because
linux cross compilation is not working for me yet:
vlang/v#10992

Fixes #17

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/19)
<!-- Reviewable:end -->
