### PR TITLE
Support functions in expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ fn example() ? {
     mut db := vsql.open('test.vsql') ?
 
     // All SQL commands use query():
-    db.query('CREATE TABLE foo (a FLOAT)') ?
+    db.query('CREATE TABLE foo (a DOUBLE PRECISION)') ?
     db.query('INSERT INTO foo (a) VALUES (1.23)') ?
     db.query('INSERT INTO foo (a) VALUES (4.56)') ?
 
@@ -204,23 +204,86 @@ Appendix
 
 ### Data Types
 
-**Important:** All data types are currently reduced to several basic internal
-types described below, which is simpler for not but has some consequences:
+**BIGINT**
 
-1. Types that might take less space in other databases (ie. `SMALLINT` vs
-`BIGINT`) will always be stored in a `f64` (8 bytes).
-2. Since all numbers are stored at 64-bit floating, some precision of large
-integers will not be maintained.
-3. Any types that contain a numerical precision or maximum string length will be
-ignored. An error will not be returned if the value stored breaches this
-requirement.
-4. The definition of a "character" isn't yet well defined or enforced. That is,
-characters can be any unicode point, but that may change the future.
-6. The intent is to have all of the above fixed in future version, so please
-choose the correct type for your values now to avoid stricter requirments in the
-future.
+`BIGINT` is an integer type.
 
-There are some types that are not supported yet:
+*TODO*
+
+1. `BIGINT` is currently in memory and on disk as a `DOUBLE PRECISION`. Keep in
+mind this may effect the precision of large values.
+2. The range of possible values is not enforced.
+
+**BOOLEAN**
+
+A `BOOLEAN` may only store a `TRUE`, `FALSE` or `UNKNOWN` value (not including a
+possible `NULL`).
+
+*TODO*
+
+1. A `BOOLEAN` is stored in memory and on disk as a 64-bit floating point
+number.
+
+**CHARACTER VARYING(n)**
+
+A `CHARACTER VARYING(n)` can store up to *n* characters.
+
+The types `CHAR VARYING(n)` and `VARCHAR(n)` are aliases for
+`CHARACTER VARYING(n)`.
+
+*TODO*
+
+1. The *n* limit is not yet enforced.
+
+**CHARACTER(n)**
+
+A `CHARACTER(n)` can store up to *n* characters. `CHARACTER(n)` differs from
+`CHARACTER VARYING(n)` in that a `CHARACTER(n)` will always be a length of *n*.
+For values that have a lesser length, the value will be padded with spaces.
+
+The types `CHAR(n)` are an alias. `CHARACTER` and `CHAR` (without a size) is an
+alias for `CHARACTER(1)`.
+
+*TODO*
+
+1. The *n* limit is not yet enforced.
+2. Values are not actually space padded.
+
+**DOUBLE PRECISION**
+
+`DOUBLE PRECISION` is a 64-bit floating point number.
+
+The `FLOAT(n)` and `FLOAT` are aliases.
+
+*TODO*
+
+1. The *n* in `FLOAT(n)` does not have any affect.
+
+**INTEGER**
+
+The type `INT` is an alias for `INTEGER`.
+
+*TODO*
+
+1. `INTEGER` is currently in memory and on disk as a `DOUBLE PRECISION`.
+2. The range of possible values is not enforced.
+
+**REAL**
+
+A `REAL` is a 32bit floating-point number.
+
+*TODO*
+
+1. `REAL` is currently in memory and on disk as a `DOUBLE PRECISION`.
+
+**SMALLINT**
+
+*TODO*
+
+1. `SMALLINT` is currently in memory and on disk as a `DOUBLE PRECISION`.
+2. The range of possible values is not enforced.
+
+**Unsupported Data Types**
 
 1. `<character large object type>`: `CHARACTER LARGE OBJECT`,
 `CHAR LARGE OBJECT` and `CLOB`.
@@ -240,24 +303,29 @@ There are some types that are not supported yet:
 12. `<array type>`: `ARRAY`.
 13. `<multiset type>`: `MULTISET`.
 
-| Type                   | Internal | Notes |
-| ---------------------- | -------- | ----- |
-| `BIGINT`               | f64      | Integer |
-| `BOOLEAN`              | f64      | `TRUE` or `FALSE` |
-| `CHAR VARYING(n)`      | string   | Alias for `CHARACTER VARYING(n)` |
-| `CHAR(n)`              | string   | Alias for `CHARACTER(n)` |
-| `CHARACTER VARYING(n)` | string   | Strings that can contain up to *n* characters |
-| `CHARACTER(n)`         | string   | Fixed width characters |
-| `CHARACTER`            | string   | Single character |
-| `CHAR`                 | string   | Alias for `CHARACTER` |
-| `DOUBLE PRECISION`     | f64      | 64bit floating-point value |
-| `FLOAT(n)`             | f64      | 64bit floating-point value |
-| `FLOAT`                | f64      | 64bit floating-point value |
-| `INTEGER`              | f64      | Integer |
-| `INT`                  | f64      | Alias for `INTEGER`. |
-| `REAL`                 | f64      | 32bit floating-point value |
-| `SMALLINT`             | f64      | Integer |
-| `VARCHAR(n)`           | string   | Alias for `CHARACTER VARYING(n)` |
+### Functions
+
+| Function                                      | Returns            | Description |
+| --------------------------------------------- | ------------------ | ----------- |
+| `ABS(DOUBLE PRECISION)`                       | `DOUBLE PRECISION` | Absolute value. |
+| `ACOS(DOUBLE PRECISION)`                      | `DOUBLE PRECISION` | Inverse (arc) cosine. |
+| `ASIN(DOUBLE PRECISION)`                      | `DOUBLE PRECISION` | Inverse (arc) sine. |
+| `ATAN(DOUBLE PRECISION)`                      | `DOUBLE PRECISION` | Inverse (arc) tangent. |
+| `CEIL(DOUBLE PRECISION)`                      | `DOUBLE PRECISION` | Round up to the nearest integer. |
+| `COS(DOUBLE PRECISION)`                       | `DOUBLE PRECISION` | Cosine. |
+| `COSH(DOUBLE PRECISION)`                      | `DOUBLE PRECISION` | Hyperbolic cosine. |
+| `EXP(DOUBLE PRECISION)`                       | `DOUBLE PRECISION` | Exponential. |
+| `FLOOR(DOUBLE PRECISION)`                     | `DOUBLE PRECISION` | Round down to the nearest integer. |
+| `LN(DOUBLE PRECISION)`                        | `DOUBLE PRECISION` | Natural logarithm (base e). |
+| `LOG(DOUBLE PRECISION)`                       | `DOUBLE PRECISION` | Logarithm in base 2. |
+| `LOG10(DOUBLE PRECISION)`                     | `DOUBLE PRECISION` | Logarithm in base 10. |
+| `MOD(DOUBLE PRECISION, DOUBLE PRECISION)`     | `DOUBLE PRECISION` | Modulus. |
+| `POWER(DOUBLE PRECISION, DOUBLE PRECISION)`   | `DOUBLE PRECISION` | Power. |
+| `SIN(DOUBLE PRECISION)`                       | `DOUBLE PRECISION` | Sine. |
+| `SINH(DOUBLE PRECISION)`                      | `DOUBLE PRECISION` | Hyperbolic sine. |
+| `SQRT(DOUBLE PRECISION)`                      | `DOUBLE PRECISION` | Square root. |
+| `TAN(DOUBLE PRECISION)`                       | `DOUBLE PRECISION` | Tangent. |
+| `TANH(DOUBLE PRECISION)`                      | `DOUBLE PRECISION` | Hyperbolic tangent. |
 
 ### Keywords
 
@@ -364,6 +432,7 @@ db.query('SELECT * FROM bar') or {
 | `42601`    | Syntax error. |
 | `42703`    | Column does not exist. |
 | `42804`    | Data type mismatch. |
+| `42883`    | Function does not exist. |
 | `42P01`    | Table does not exist. |
 | `42P07`    | Table already exists. |
 

--- a/tests/math.sql
+++ b/tests/math.sql
@@ -1,0 +1,71 @@
+SELECT ABS(1.2), ABS(-1.23);
+-- COL1: 1.2 COL2: 1.23
+
+SELECT ABS('hello');
+-- error 42804: data type mismatch argument 1 in ABS: expected DOUBLE PRECISION but got CHARACTER VARYING
+
+SELECT ABS();
+-- error 42883: function does not exist: ABS has 0 arguments but needs 1 argument
+
+SELECT ABS(1, 2);
+-- error 42883: function does not exist: ABS has 2 arguments but needs 1 argument
+
+SELECT SIN(1.2);
+-- COL1: 0.932039
+
+SELECT COS(1.2);
+-- COL1: 0.362358
+
+SELECT TAN(1.2);
+-- COL1: 2.572152
+
+SELECT SINH(1.2);
+-- COL1: 1.509461
+
+SELECT COSH(1.2);
+-- COL1: 1.810656
+
+SELECT TANH(1.2);
+-- COL1: 0.833655
+
+SELECT ASIN(0.2);
+-- COL1: 0.201358
+
+SELECT ACOS(0.2);
+-- COL1: 1.369438
+
+SELECT ATAN(0.2);
+-- COL1: 0.197396
+
+SELECT MOD(232, 3);
+-- COL1: 1
+
+SELECT MOD(10.7, 0.8);
+-- COL1: 0.3
+
+SELECT LOG(13.7);
+-- COL1: 3.776104
+
+SELECT LOG10(13.7);
+-- COL1: 1.136721
+
+SELECT LN(13.7);
+-- COL1: 2.617396
+
+SELECT EXP(3.7);
+-- COL1: 40.447304
+
+SELECT POWER(3.7, 2.5);
+-- COL1: 26.333241
+
+SELECT SQRT(3.7);
+-- COL1: 1.923538
+
+SELECT FLOOR(3.7), FLOOR(3.3), FLOOR(-3.7), FLOOR(-3.3);
+-- COL1: 3 COL2: 3 COL3: -4 COL4: -4
+
+SELECT CEIL(3.7), CEIL(3.3), CEIL(-3.7), CEIL(-3.3);
+-- COL1: 4 COL2: 4 COL3: -3 COL4: -3
+
+SELECT CEILING(3.7);
+-- COL1: 4

--- a/tests/update.sql
+++ b/tests/update.sql
@@ -32,7 +32,7 @@ SELECT * FROM foo;
 CREATE TABLE foo (baz FLOAT);
 UPDATE foo SET baz = true;
 -- msg: CREATE TABLE 1
--- error 42804: data type mismatch for column BAZ: expected FLOAT but got BOOLEAN
+-- error 42804: data type mismatch for column BAZ: expected DOUBLE PRECISION but got BOOLEAN
 
 CREATE TABLE foo (baz FLOAT);
 INSERT INTO foo (baz) VALUES (123);

--- a/vsql-cli.v
+++ b/vsql-cli.v
@@ -37,12 +37,7 @@ fn main_command(cmd cli.Command) ? {
 			println('')
 		}
 
-		mut row_word := 'rows'
-		if result.rows.len == 1 {
-			row_word = 'row'
-		}
-		println('$result.rows.len $row_word (${time.ticks() - start} ms)')
-
+		println('$result.rows.len ${vsql.pluralize(result.rows.len, 'row')} (${time.ticks() - start} ms)')
 		println('')
 	}
 }

--- a/vsql/ast.v
+++ b/vsql/ast.v
@@ -6,7 +6,7 @@ module vsql
 type Stmt = CreateTableStmt | DeleteStmt | DropTableStmt | InsertStmt | SelectStmt | UpdateStmt
 
 // All possible expression entities.
-type Expr = BinaryExpr | Identifier | NoExpr | NullExpr | UnaryExpr | Value
+type Expr = BinaryExpr | CallExpr | Identifier | NoExpr | NullExpr | UnaryExpr | Value
 
 // CREATE TABLE ...
 struct CreateTableStmt {
@@ -71,4 +71,9 @@ struct BinaryExpr {
 // NoExpr is just a placeholder when there is no expression provided.
 struct NoExpr {
 	dummy int // empty struct not allowed
+}
+
+struct CallExpr {
+	function_name string
+	args          []Expr
 }

--- a/vsql/cast.v
+++ b/vsql/cast.v
@@ -19,7 +19,7 @@ fn cast(msg string, v Value, to Type) ?Value {
 		}
 		.is_bigint {
 			match to.typ {
-				.is_bigint, .is_float, .is_integer, .is_real, .is_smallint { return v }
+				.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint { return v }
 				else {}
 			}
 		}
@@ -29,27 +29,27 @@ fn cast(msg string, v Value, to Type) ?Value {
 				else {}
 			}
 		}
-		.is_float {
+		.is_double_precision {
 			match to.typ {
-				.is_bigint, .is_float, .is_integer, .is_real, .is_smallint { return v }
+				.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint { return v }
 				else {}
 			}
 		}
 		.is_integer {
 			match to.typ {
-				.is_bigint, .is_float, .is_integer, .is_real, .is_smallint { return v }
+				.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint { return v }
 				else {}
 			}
 		}
 		.is_real {
 			match to.typ {
-				.is_bigint, .is_float, .is_integer, .is_real, .is_smallint { return v }
+				.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint { return v }
 				else {}
 			}
 		}
 		.is_smallint {
 			match to.typ {
-				.is_bigint, .is_float, .is_integer, .is_real, .is_smallint { return v }
+				.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint { return v }
 				else {}
 			}
 		}

--- a/vsql/connection.v
+++ b/vsql/connection.v
@@ -6,10 +6,16 @@ module vsql
 struct Connection {
 mut:
 	storage FileStorage
+	funcs   map[string]Func
 }
 
 pub fn open(path string) ?Connection {
-	return Connection{new_file_storage(path) ?}
+	mut conn := Connection{
+		storage: new_file_storage(path) ?
+	}
+	register_builtin_funcs(mut conn) ?
+
+	return conn
 }
 
 pub fn (mut c Connection) query(sql string) ?Result {
@@ -35,4 +41,8 @@ pub fn (mut c Connection) query(sql string) ?Result {
 			return c.update(stmt)
 		}
 	}
+}
+
+pub fn (mut c Connection) register_func(func Func) ? {
+	c.funcs[func.name] = func
 }

--- a/vsql/delete.v
+++ b/vsql/delete.v
@@ -16,7 +16,7 @@ fn (mut c Connection) delete(stmt DeleteStmt) ?Result {
 	for row in rows {
 		mut ok := true
 		if stmt.where !is NoExpr {
-			ok = eval_as_bool(row, stmt.where) ?
+			ok = eval_as_bool(c, row, stmt.where) ?
 		}
 
 		if ok {

--- a/vsql/funcs.v
+++ b/vsql/funcs.v
@@ -1,0 +1,36 @@
+// funcs.v registers all the inbuilt SQL functions.
+
+module vsql
+
+struct Func {
+	name      string
+	arg_types []Type
+	func      fn ([]Value) ?Value
+}
+
+fn register_builtin_funcs(mut conn Connection) ? {
+	conn.register_func(Func{'ABS', [Type{SQLType.is_double_precision, 0}], func_abs}) ?
+	conn.register_func(Func{'ACOS', [Type{SQLType.is_double_precision, 0}], func_acos}) ?
+	conn.register_func(Func{'ASIN', [Type{SQLType.is_double_precision, 0}], func_asin}) ?
+	conn.register_func(Func{'ATAN', [Type{SQLType.is_double_precision, 0}], func_atan}) ?
+	conn.register_func(Func{'CEIL', [Type{SQLType.is_double_precision, 0}], func_ceil}) ?
+	conn.register_func(Func{'CEILING', [Type{SQLType.is_double_precision, 0}], func_ceil}) ?
+	conn.register_func(Func{'COS', [Type{SQLType.is_double_precision, 0}], func_cos}) ?
+	conn.register_func(Func{'COSH', [Type{SQLType.is_double_precision, 0}], func_cosh}) ?
+	conn.register_func(Func{'EXP', [Type{SQLType.is_double_precision, 0}], func_exp}) ?
+	conn.register_func(Func{'FLOOR', [Type{SQLType.is_double_precision, 0}], func_floor}) ?
+	conn.register_func(Func{'LN', [Type{SQLType.is_double_precision, 0}], func_ln}) ?
+	conn.register_func(Func{'LOG', [Type{SQLType.is_double_precision, 0}], func_log}) ?
+	conn.register_func(Func{'LOG10', [Type{SQLType.is_double_precision, 0}], func_log10}) ?
+	conn.register_func(Func{'MOD', [Type{SQLType.is_double_precision, 0},
+		Type{SQLType.is_double_precision, 0},
+	], func_mod}) ?
+	conn.register_func(Func{'POWER', [Type{SQLType.is_double_precision, 0},
+		Type{SQLType.is_double_precision, 0},
+	], func_power}) ?
+	conn.register_func(Func{'SIN', [Type{SQLType.is_double_precision, 0}], func_sin}) ?
+	conn.register_func(Func{'SINH', [Type{SQLType.is_double_precision, 0}], func_sinh}) ?
+	conn.register_func(Func{'SQRT', [Type{SQLType.is_double_precision, 0}], func_sqrt}) ?
+	conn.register_func(Func{'TAN', [Type{SQLType.is_double_precision, 0}], func_tan}) ?
+	conn.register_func(Func{'TANH', [Type{SQLType.is_double_precision, 0}], func_tanh}) ?
+}

--- a/vsql/math.v
+++ b/vsql/math.v
@@ -1,0 +1,100 @@
+// math.v contains all the mathematical/numeric built in SQL functions.
+
+module vsql
+
+import math
+
+// ABS(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_abs(args []Value) ?Value {
+	return new_double_precision_value(math.abs(args[0].f64_value))
+}
+
+// SIN(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_sin(args []Value) ?Value {
+	return new_double_precision_value(math.sin(args[0].f64_value))
+}
+
+// COS(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_cos(args []Value) ?Value {
+	return new_double_precision_value(math.cos(args[0].f64_value))
+}
+
+// TAN(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_tan(args []Value) ?Value {
+	return new_double_precision_value(math.tan(args[0].f64_value))
+}
+
+// SINH(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_sinh(args []Value) ?Value {
+	return new_double_precision_value(math.sinh(args[0].f64_value))
+}
+
+// COSH(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_cosh(args []Value) ?Value {
+	return new_double_precision_value(math.cosh(args[0].f64_value))
+}
+
+// TANH(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_tanh(args []Value) ?Value {
+	return new_double_precision_value(math.tanh(args[0].f64_value))
+}
+
+// ASIN(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_asin(args []Value) ?Value {
+	return new_double_precision_value(math.asin(args[0].f64_value))
+}
+
+// ACOS(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_acos(args []Value) ?Value {
+	return new_double_precision_value(math.acos(args[0].f64_value))
+}
+
+// ATAN(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_atan(args []Value) ?Value {
+	return new_double_precision_value(math.atan(args[0].f64_value))
+}
+
+// MOD(DOUBLE PRECISION, DOUBLE PRECISION) DOUBLE PRECISION
+fn func_mod(args []Value) ?Value {
+	return new_double_precision_value(math.fmod(args[0].f64_value, args[1].f64_value))
+}
+
+// LOG(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_log(args []Value) ?Value {
+	return new_double_precision_value(math.log2(args[0].f64_value))
+}
+
+// LOG10(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_log10(args []Value) ?Value {
+	return new_double_precision_value(math.log10(args[0].f64_value))
+}
+
+// LN(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_ln(args []Value) ?Value {
+	return new_double_precision_value(math.log(args[0].f64_value))
+}
+
+// EXP(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_exp(args []Value) ?Value {
+	return new_double_precision_value(math.exp(args[0].f64_value))
+}
+
+// SQRT(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_sqrt(args []Value) ?Value {
+	return new_double_precision_value(math.sqrt(args[0].f64_value))
+}
+
+// POWER(DOUBLE PRECISION, DOUBLE PRECISION) DOUBLE PRECISION
+fn func_power(args []Value) ?Value {
+	return new_double_precision_value(math.pow(args[0].f64_value, args[1].f64_value))
+}
+
+// FLOOR(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_floor(args []Value) ?Value {
+	return new_double_precision_value(math.floor(args[0].f64_value))
+}
+
+// CEIL(DOUBLE PRECISION) DOUBLE PRECISION
+fn func_ceil(args []Value) ?Value {
+	return new_double_precision_value(math.ceil(args[0].f64_value))
+}

--- a/vsql/row.v
+++ b/vsql/row.v
@@ -16,8 +16,8 @@ pub fn (r Row) get_null(name string) ?bool {
 	return value.typ.typ == .is_null
 }
 
-// get_f64 will only work for columns that are numerical (FLOAT, REAL, etc). If
-// the value is NULL, 0 will be returned. See get_null().
+// get_f64 will only work for columns that are numerical (DOUBLE PRECISION,
+// FLOAT, REAL, etc). If the value is NULL, 0 will be returned. See get_null().
 pub fn (r Row) get_f64(name string) ?f64 {
 	value := r.get(name) ?
 	if value.typ.uses_f64() {
@@ -37,7 +37,7 @@ pub fn (r Row) get_string(name string) ?string {
 	return match value.typ.typ {
 		.is_null { 'NULL' }
 		.is_boolean { bool_str(r.data[name].f64_value) }
-		.is_float, .is_real, .is_bigint, .is_integer, .is_smallint { f64_string(r.data[name].f64_value) }
+		.is_double_precision, .is_real, .is_bigint, .is_integer, .is_smallint { f64_string(r.data[name].f64_value) }
 		.is_varchar, .is_character { r.data[name].string_value }
 	}
 }

--- a/vsql/select.v
+++ b/vsql/select.v
@@ -11,7 +11,7 @@ fn (mut c Connection) query_select(stmt SelectStmt) ?Result {
 
 			mut rows := c.storage.read_rows(table.index) ?
 			if stmt.where !is NoExpr {
-				rows = where(rows, false, stmt.where) ?
+				rows = where(c, rows, false, stmt.where) ?
 			}
 
 			return new_result(table.column_names(), rows)
@@ -28,7 +28,7 @@ fn (mut c Connection) query_select(stmt SelectStmt) ?Result {
 	}
 	for expr in stmt.exprs {
 		column_name := 'COL$col_num'
-		data[column_name] = eval_as_value(empty_row, expr) ?
+		data[column_name] = eval_as_value(c, empty_row, expr) ?
 		cols << column_name
 		col_num++
 	}

--- a/vsql/sqlstate.v
+++ b/vsql/sqlstate.v
@@ -154,3 +154,19 @@ fn sqlstate_42p07(table_name string) IError {
 		table_name: table_name
 	}
 }
+
+// No such function
+struct SQLState42883 {
+	msg  string
+	code int
+pub:
+	function_name string
+}
+
+fn sqlstate_42883(function_name string) IError {
+	return SQLState42883{
+		code: sqlstate_to_int('42883')
+		msg: 'function does not exist: $function_name'
+		function_name: function_name
+	}
+}

--- a/vsql/storage.v
+++ b/vsql/storage.v
@@ -81,7 +81,7 @@ fn (mut f FileStorage) write_value(v Value) ? {
 
 	match v.typ.typ {
 		.is_null {}
-		.is_boolean, .is_float, .is_bigint, .is_integer, .is_real, .is_smallint {
+		.is_boolean, .is_double_precision, .is_bigint, .is_integer, .is_real, .is_smallint {
 			f.write<f64>(v.f64_value) ?
 		}
 		.is_varchar, .is_character {
@@ -100,7 +100,7 @@ fn (mut f FileStorage) read_value() ?Value {
 		.is_null {
 			new_null_value()
 		}
-		.is_boolean, .is_bigint, .is_float, .is_real, .is_smallint, .is_integer {
+		.is_boolean, .is_bigint, .is_double_precision, .is_real, .is_smallint, .is_integer {
 			Value{
 				typ: Type{typ, 0}
 				f64_value: f.read<f64>() ?
@@ -122,7 +122,7 @@ fn (mut f FileStorage) read_value() ?Value {
 fn sizeof_value(value Value) int {
 	return int(sizeof(SQLType) + match value.typ.typ {
 		.is_null { 0 }
-		.is_boolean, .is_float, .is_integer, .is_bigint, .is_smallint, .is_real { sizeof(f64) }
+		.is_boolean, .is_double_precision, .is_integer, .is_bigint, .is_smallint, .is_real { sizeof(f64) }
 		.is_varchar, .is_character { sizeof(int) + u32(value.string_value.len) }
 	})
 }
@@ -217,7 +217,7 @@ fn (mut f FileStorage) create_table(table_name string, columns []Column) ? {
 	offset := u32(f.f.tell() ?)
 
 	// If index is 0, the table is deleletd
-	values << new_float_value(index)
+	values << new_double_precision_value(index)
 	values << new_varchar_value(table_name, 0)
 
 	for column in columns {
@@ -234,7 +234,7 @@ fn (mut f FileStorage) delete_table(table_name string) ? {
 	f.f.seek(f.tables[table_name].offset, .start) ?
 
 	// If index is 0, the table is deleted
-	f.write_value(new_float_value(0)) ?
+	f.write_value(new_double_precision_value(0)) ?
 
 	f.tables.delete(table_name)
 }

--- a/vsql/type.v
+++ b/vsql/type.v
@@ -11,8 +11,8 @@ enum SQLType {
 	is_null // NULL
 	is_bigint // BIGINT
 	is_boolean // BOOLEAN
-	is_character // CHARACTER and CHAR
-	is_float // FLOAT and DOUBLE PRECISION
+	is_character // CHARACTER(n), CHAR(n), CHARACTER and CHAR
+	is_double_precision // DOUBLE PRECISION, FLOAT and FLOAT(n)
 	is_integer // INTEGER and INT
 	is_real // REAL
 	is_smallint // SMALLINT
@@ -25,7 +25,7 @@ fn (t SQLType) str() string {
 		.is_bigint { 'BIGINT' }
 		.is_boolean { 'BOOLEAN' }
 		.is_character { 'CHARACTER' }
-		.is_float { 'FLOAT' }
+		.is_double_precision { 'DOUBLE PRECISION' }
 		.is_integer { 'INTEGER' }
 		.is_real { 'REAL' }
 		.is_smallint { 'SMALLINT' }
@@ -47,8 +47,8 @@ fn new_type(name string, size int) Type {
 		'CHARACTER', 'CHAR' {
 			Type{.is_character, size}
 		}
-		'FLOAT', 'DOUBLE PRECISION' {
-			Type{.is_float, size}
+		'DOUBLE PRECISION', 'FLOAT' {
+			Type{.is_double_precision, size}
 		}
 		'REAL' {
 			Type{.is_real, size}
@@ -72,14 +72,19 @@ fn (t Type) str() string {
 
 fn (t Type) uses_f64() bool {
 	return match t.typ {
-		.is_boolean, .is_float, .is_bigint, .is_real, .is_smallint, .is_integer { true }
+		.is_boolean, .is_double_precision, .is_bigint, .is_real, .is_smallint, .is_integer { true }
 		.is_null, .is_varchar, .is_character { false }
 	}
 }
 
 fn (t Type) uses_string() bool {
 	return match t.typ {
-		.is_null, .is_boolean, .is_float, .is_bigint, .is_real, .is_smallint, .is_integer { false }
-		.is_varchar, .is_character { true }
+		.is_null, .is_boolean, .is_double_precision, .is_bigint, .is_real, .is_smallint,
+		.is_integer {
+			false
+		}
+		.is_varchar, .is_character {
+			true
+		}
 	}
 }

--- a/vsql/update.v
+++ b/vsql/update.v
@@ -28,7 +28,7 @@ fn (mut c Connection) update(stmt UpdateStmt) ?Result {
 		// Missing WHERE matches all records
 		mut ok := true
 		if stmt.where !is NoExpr {
-			ok = eval_as_bool(row, stmt.where) ?
+			ok = eval_as_bool(c, row, stmt.where) ?
 		}
 
 		if ok {

--- a/vsql/utils.v
+++ b/vsql/utils.v
@@ -1,0 +1,13 @@
+// utils.v is just general helpful functions that don't fall into any specific
+// category.
+
+module vsql
+
+// TODO(elliotchance): Make private when CLI is moved into vsql package.
+pub fn pluralize(n int, word string) string {
+	if n == 1 {
+		return word
+	}
+
+	return '${word}s'
+}

--- a/vsql/value.v
+++ b/vsql/value.v
@@ -31,9 +31,9 @@ pub fn new_unknown_value() Value {
 	}
 }
 
-pub fn new_float_value(x f64) Value {
+pub fn new_double_precision_value(x f64) Value {
 	return Value{
-		typ: Type{.is_float, 0}
+		typ: Type{.is_double_precision, 0}
 		f64_value: x
 	}
 }
@@ -57,7 +57,7 @@ pub fn (v Value) == (v2 Value) bool {
 		.is_null {
 			false
 		}
-		.is_boolean, .is_bigint, .is_integer, .is_smallint, .is_float, .is_real {
+		.is_boolean, .is_bigint, .is_integer, .is_smallint, .is_double_precision, .is_real {
 			v2.typ.typ == v.typ.typ && v.f64_value == v2.f64_value
 		}
 		.is_varchar, .is_character {

--- a/vsql/where.v
+++ b/vsql/where.v
@@ -2,10 +2,10 @@
 
 module vsql
 
-fn where(rows []Row, inverse bool, expr Expr) ?[]Row {
+fn where(conn Connection, rows []Row, inverse bool, expr Expr) ?[]Row {
 	mut new_rows := []Row{}
 	for row in rows {
-		mut ok := eval_as_bool(row, expr) ?
+		mut ok := eval_as_bool(conn, row, expr) ?
 		if inverse {
 			ok = !ok
 		}


### PR DESCRIPTION
- Expressions now support functions, starting with some common SQL
standard functions `ABS`, `SIN`, `COS`, `TAN`, `ACOS`, `ASIN`, `ATAN`,
`SINH`, `COSH`, `TANH`, `MOD`, `LOG`, `LOG10`, `LN`, `EXP`, `POWER`,
`SQRT`, `FLOOR`, `CEIL` and `CEILING`.
- Better documentation around types and their specific limitations.
Including replacing cases of `FLOAT` with the more appropriate
`DOUBLE PRECISION` (since `FLOAT` is an alias).
- Added SQLSTATE 42883: no such function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/21)
<!-- Reviewable:end -->
