### PR TITLE
Adding support for "AS" aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,13 @@ column := <column_name> <column_type> [ NULL | NOT NULL ]
 underscore (`_`) or digit for a maximum length of 128 characters.
 2. `column_type` must be one of the [Data Types](#data-types).
 
-Example:
+**Example**
 
 ```sql
 CREATE TABLE products (
     title CHARACTER VARYING(100),
     price FLOAT
-)
+);
 ```
 
 ## DELETE
@@ -165,24 +165,45 @@ VALUES ( <value> , ... )
 
 The number of `col`s and `value`s must match.
 
-Example:
+**Examples**
 
 ```sql
-INSERT INTO products (title, price) VALUES ('Instant Pot', 144.89)
+INSERT INTO products (title, price) VALUES ('Instant Pot', 144.89);
 ```
 
 ## SELECT
 
 ```
-SELECT <field> , ...
+SELECT <expression> [ AS <name> ] , ...
 [ FROM <table_name> ]
-[ WHERE <expr> ]
+[ WHERE <condition> ]
 ```
 
-Examples:
+The SQL standard defines two types of identifiers: regular and delimited. A
+regular identifier is a word (such as `foo`) whereas a delimited identifier is
+surrounded by double-quotes (such as `"foo"`). A regular identifier is always
+converted to upper-case, whereas as delimited identifier keeps it's case. This
+applies to any identifier (table names, column names, `AS` names, etc).
+
+For each *expression*, the naming convention follows:
+
+1. If `name` is provided, that will be used.
+2. If `expression` refered to a column, the column name will be used.
+3. Otherwise, the name `COL<number>` will be used where *number* is the position
+of the column (starting at 1).
+
+If `FROM` is not provided, the result will always be one row containing the
+result of the expressions.
+
+If `WHERE` is not provided all rows are returned.
+
+**Examples**
 
 ```sql
-SELECT * FROM products
+SELECT * FROM products;
+
+SELECT price * (1 + tax) AS total
+FROM products;
 ```
 
 ## UPDATE

--- a/tests/as.sql
+++ b/tests/as.sql
@@ -1,0 +1,11 @@
+SELECT 1 AS bob;
+-- BOB: 1
+
+SELECT 1 AS "Bob";
+-- Bob: 1
+
+SELECT 'foo' || 'bar' AS Str;
+-- STR: foobar
+
+SELECT 1 + 2 AS total1, 3 + 4 AS total2;
+-- TOTAL1: 3 TOTAL2: 7

--- a/tests/reserved-words.sql
+++ b/tests/reserved-words.sql
@@ -32,7 +32,7 @@ CREATE TABLE ARRAY_MAX_CARDINALITY (a INT);
 -- error 42601: syntax error: table name cannot be reserved word: ARRAY_MAX_CARDINALITY
 
 CREATE TABLE AS (a INT);
--- error 42601: syntax error: table name cannot be reserved word: AS
+-- error 42601: syntax error: expecting literal_identifier but found AS
 
 CREATE TABLE ASENSITIVE (a INT);
 -- error 42601: syntax error: table name cannot be reserved word: ASENSITIVE

--- a/vsql/ast.v
+++ b/vsql/ast.v
@@ -6,7 +6,8 @@ module vsql
 type Stmt = CreateTableStmt | DeleteStmt | DropTableStmt | InsertStmt | SelectStmt | UpdateStmt
 
 // All possible expression entities.
-type Expr = BinaryExpr | CallExpr | Identifier | NoExpr | NullExpr | UnaryExpr | Value
+type Expr = BinaryExpr | CallExpr | Identifier | NamedExpr | NoExpr | NullExpr | UnaryExpr |
+	Value
 
 // CREATE TABLE ...
 struct CreateTableStmt {
@@ -76,4 +77,10 @@ struct NoExpr {
 struct CallExpr {
 	function_name string
 	args          []Expr
+}
+
+// NamedExpr wraps an "AS" expression.
+struct NamedExpr {
+	name string
+	expr Expr
 }

--- a/vsql/eval.v
+++ b/vsql/eval.v
@@ -7,6 +7,7 @@ fn eval_as_value(conn Connection, data Row, e Expr) ?Value {
 		BinaryExpr { return eval_binary(conn, data, e) }
 		CallExpr { return eval_call(conn, data, e) }
 		Identifier { return eval_identifier(data, e) }
+		NamedExpr { return eval_as_value(conn, data, e.expr) }
 		NullExpr { return eval_null(conn, data, e) }
 		NoExpr { return sqlstate_42601('no expression provided') }
 		UnaryExpr { return eval_unary(conn, data, e) }

--- a/vsql/lexer.v
+++ b/vsql/lexer.v
@@ -14,6 +14,7 @@ enum TokenKind {
 	greater_than_operator // <greater than operator> ::= >
 	greater_than_or_equals_operator // <greater than or equals operator> ::= >=
 	keyword_and // AND
+	keyword_as // AS
 	keyword_bigint // BIGINT
 	keyword_boolean // BOOLEAN
 	keyword_char // CHAR
@@ -166,6 +167,7 @@ fn tokenize(sql string) []Token {
 		}
 
 		tokens << match word.to_upper() {
+			'AS' { Token{TokenKind.keyword_as, word} }
 			'AND' { Token{TokenKind.keyword_and, word} }
 			'BIGINT' { Token{TokenKind.keyword_bigint, word} }
 			'BOOLEAN' { Token{TokenKind.keyword_boolean, word} }

--- a/vsql/storage.v
+++ b/vsql/storage.v
@@ -111,9 +111,14 @@ fn (mut f FileStorage) read_value() ?Value {
 			mut buf := []byte{len: len}
 			f.f.read(mut buf) ?
 
+			// TODO(elliotchance): There seems to be a weird bug where
+			//  converting some bytes to a string ends up with a string that
+			//  also contains the NULL character. ie 'DOUBLE PRECISION' (16
+			//  bytes) becomes 'DOUBLE PRECISION\0' (17 bytes). The [..buf.len]
+			//  is a temporary protection against this.
 			Value{
 				typ: Type{typ, 0}
-				string_value: string(buf)
+				string_value: string(buf)[..buf.len]
 			}
 		}
 	}


### PR DESCRIPTION
The `AS` in `SELECT` statements allow custom column names to be used.
Also, fixed a bug with `*` not being handled correctly in SELECT
expressions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/22)
<!-- Reviewable:end -->
