### PR TITLE
Adding virtual tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ no dependencies.
   - [CLI](#cli)
   - [Server](#server)
   - [Custom Functions](#custom-functions)
+  - [Virtual Tables](#virtual-tables)
 - [FAQ](https://github.com/elliotchance/vsql/blob/main/docs/faq.rst)
 - SQL Commands
   - [CREATE TABLE](https://github.com/elliotchance/vsql/blob/main/docs/create-table.rst)
@@ -148,6 +149,41 @@ for row in result {
 A function must return a value to match the return type. See the full list of
 `Value` constructors in
 [value.v](https://github.com/elliotchance/vsql/blob/main/vsql/value.v).
+
+### Virtual Tables
+
+Virtual tables allow you to register tables that have their rows provided at the
+time of a `SELECT`:
+
+```v
+db.register_virtual_table(
+  'CREATE TABLE foo ( "num" INT, word VARCHAR (32) )',
+  fn (mut t vsql.VirtualTable) ? {
+    t.next_values([
+      vsql.new_double_precision_value(1)
+      vsql.new_varchar_value("hi", 0)
+    ])
+
+    t.next_values([
+      vsql.new_double_precision_value(2)
+      vsql.new_varchar_value("there", 0)
+    ])
+
+    t.done()
+  }
+) ?
+
+result := db.query('SELECT * FROM foo') ?
+for row in result {
+  num := row.get_f64('num') ?
+  word := row.get_string('WORD') ?
+  println('$num $word')
+}
+```
+
+The callback for the virtual table will be called repeatedly until `t.done()` is
+invoked, even if zero rows are provided in an iteration. All data will be thrown
+away between subsequent `SELECT` operations.
 
 Testing
 -------

--- a/examples/virtual-tables.v
+++ b/examples/virtual-tables.v
@@ -1,0 +1,32 @@
+import os
+import vsql
+
+fn main() {
+	os.rm('test.vsql') or {}
+	example() or { panic(err) }
+}
+
+fn example() ? {
+	mut db := vsql.open('test.vsql') ?
+
+	db.register_virtual_table('CREATE TABLE foo ( "num" INT, word VARCHAR (32) )', fn (mut t vsql.VirtualTable) ? {
+		t.next_values([
+			vsql.new_double_precision_value(1),
+			vsql.new_varchar_value('hi', 0),
+		])
+
+		t.next_values([
+			vsql.new_double_precision_value(2),
+			vsql.new_varchar_value('there', 0),
+		])
+
+		t.done()
+	}) ?
+
+	result := db.query('SELECT * FROM foo') ?
+	for row in result {
+		num := row.get_f64('num') ?
+		word := row.get_string('WORD') ?
+		println('$num $word')
+	}
+}

--- a/generate-grammar.py
+++ b/generate-grammar.py
@@ -1,4 +1,5 @@
 import re
+import sys
 
 # type RuleOrString = EarleyRule | string
 
@@ -512,3 +513,7 @@ def parse_tree(text):
 # parse_tree("SELECT * FROM t OFFSET 0 ROWS")
 # parse_tree("SELECT * FROM t FETCH FIRST 1 ROW ONLY")
 # parse_tree("SELECT product_name , no_pennies ( price ) AS total FROM products")
+
+for arg in sys.argv[1:]:
+    print(arg)
+    parse_tree(arg)

--- a/vsql/row.v
+++ b/vsql/row.v
@@ -9,6 +9,12 @@ mut:
 	data   map[string]Value
 }
 
+pub fn new_row(data map[string]Value) Row {
+	return Row{
+		data: data
+	}
+}
+
 // get_null will return true if the column name is NULL. An error will be
 // returned if the column does not exist.
 pub fn (r Row) get_null(name string) ?bool {

--- a/vsql/virtual_table.v
+++ b/vsql/virtual_table.v
@@ -1,0 +1,29 @@
+module vsql
+
+struct VirtualTable {
+	create_table_sql  string
+	create_table_stmt CreateTableStmt
+	data              fn (mut t VirtualTable) ?
+mut:
+	is_done bool
+	rows    []Row
+}
+
+fn (mut v VirtualTable) reset() {
+	v.is_done = false
+	v.rows = []Row{}
+}
+
+pub fn (mut v VirtualTable) next_values(values []Value) {
+	mut row := map[string]Value{}
+	mut i := 0
+	for col in v.create_table_stmt.columns {
+		row[identifier_name(col.name)] = values[i]
+		i++
+	}
+	v.rows << new_row(row)
+}
+
+pub fn (mut v VirtualTable) done() {
+	v.is_done = true
+}


### PR DESCRIPTION
Virtual tables allow you to register tables that have their rows
provided at the time of a `SELECT`. The callback for the virtual
table will be called repeatedly until `t.done()` is invoked, even if
zero rows are provided in an iteration. All data will be thrown away
between subsequent `SELECT` operations.

There are a couple of reasons why this is needed:

1. When using vsql as a PostgreSQL server, there are various tables that
different client access (such as `pg_database`) that can be provided
virtually during the connection but do not need to exist as real tables
just to satisfy the connection.

2. It's handy to be able to inject memory-based runtime data from a V
program to interact, or be used exclusively with the database engine.
Apart from virtual tables being faster, it makes SQL-based ETL much
easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/28)
<!-- Reviewable:end -->
