### PR TITLE
server: Added SSL negotiation

### DIFF
--- a/cmd/vsql.v
+++ b/cmd/vsql.v
@@ -19,6 +19,18 @@ fn main() {
 		required_args: 1
 		execute: server_command
 	}
+	server_cmd.add_flag(cli.Flag{
+		flag: .bool
+		name: 'verbose'
+		abbrev: 'v'
+		description: 'Verbose (show all messages in and out of the server)'
+	})
+	server_cmd.add_flag(cli.Flag{
+		flag: .int
+		name: 'port'
+		abbrev: 'p'
+		description: 'Port number (default 3210)'
+	})
 	cmd.add_command(server_cmd)
 
 	cmd.setup()
@@ -49,8 +61,17 @@ fn cli_command(cmd cli.Command) ? {
 }
 
 fn server_command(cmd cli.Command) {
+	mut port := cmd.flags.get_int('port') or { 0 }
+	if port == 0 {
+		port = 3210
+	}
+
 	// TODO(elliotchance): Make port a CLI option.
-	mut server := vsql.new_server(cmd.args[0], 3210)
+	mut server := vsql.new_server(vsql.ServerOptions{
+		db_file: cmd.args[0]
+		port: port
+		verbose: cmd.flags.get_bool('verbose') or { false }
+	})
 
 	server.start() or { panic(err) }
 }

--- a/docs/supported-clients.rst
+++ b/docs/supported-clients.rst
@@ -22,18 +22,20 @@ Generally speaking, the connection details are:
 Command Line
 ============
 
-psql
-----
+✔ psql
+------
 
-The official PostgreSQL command line client is **not supported**. There seems to
-be a timeout when connecting. See
-`the ticket here <https://github.com/elliotchance/vsql/issues/29>`_.
+The official PostgreSQL command line client is supported:
+
+.. code-block:: sh
+
+  psql -h 127.0.0.1 -p 3210
 
 GUI Applications
 ================
 
-TablePlus
----------
+✔ TablePlus
+-----------
 
 TablePlus is supported using the following connection options:
 
@@ -47,15 +49,15 @@ TablePlus is supported using the following connection options:
 VSCode
 ======
 
-PostgreSQL (ckolkman.vscode-postgres)
--------------------------------------
+✖ PostgreSQL (ckolkman.vscode-postgres)
+---------------------------------------
 
-This extension is **not supported** because it executes several complex queries.
+This extension is not supported because it executes several complex queries.
 You can view some
 `sample queries here <https://gist.github.com/elliotchance/257951d705132134b882258c83297dd6>`_.
 
-SQLTools (mtxr.sqltools)
-------------------------
+✔ SQLTools (mtxr.sqltools)
+--------------------------
 
 This is extension is supported. There are some queries executed that are not
 compatible, but this doesn't block the connection or execution of custom


### PR DESCRIPTION
A client may ask if the server supports SSL through a special
StartupMessage. This is now supported and was the cause of psql hanging
on connect.

Added a "-v" option to the server (disabled by default) to hide all of
the sent and received messages (which may be helpful for debugging).

Added a "-p" option to set the server port.

Fixes #29

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/31)
<!-- Reviewable:end -->
