### PR TITLE
Fix expressions in INSERT and UPDATE

### DIFF
--- a/docs/select.rst
+++ b/docs/select.rst
@@ -12,7 +12,7 @@ Syntax
 .. code-block:: txt
 
   SELECT <expression> [ AS <name> ] , ...
-  [ FROM <table_name> ]
+  FROM <table_name>
   [ WHERE <condition> ]
   [ OFFSET <integer> { ROW | ROWS } ]
   [ FETCH FIRST <integer> { ROW | ROWS } ONLY ]
@@ -25,12 +25,6 @@ For each *expression*, the naming convention follows:
 1. If ``name`` is provided, that will be used.
 2. If ``expression`` refered to a column, the column name will be used.
 3. Otherwise, the name ``COL<number>`` will be used where *number* is the position of the column (starting at 1).
-  
-FROM
-----
-
-If ``FROM`` is not provided, the result will always be one row containing the
-result of the expressions.
 
 WHERE
 -----

--- a/tests/insert.sql
+++ b/tests/insert.sql
@@ -88,3 +88,10 @@ INSERT INTO t1 (f1) VALUES ('a');
 SELECT * FROM t1;
 -- msg: CREATE TABLE 1
 -- error 23502: violates non-null constraint: column F2
+
+CREATE TABLE t1 (f1 FLOAT NOT NULL);
+INSERT INTO t1 (f1) VALUES (-123 * 4.2);
+SELECT * FROM t1;
+-- msg: CREATE TABLE 1
+-- msg: INSERT 1
+-- F1: -516.6

--- a/tests/update.sql
+++ b/tests/update.sql
@@ -49,3 +49,21 @@ UPDATE foo SET baz = NULL;
 -- msg: CREATE TABLE 1
 -- msg: INSERT 1
 -- error 23502: violates non-null constraint: column BAZ
+
+CREATE TABLE foo (baz FLOAT);
+INSERT INTO foo (baz) VALUES (-123);
+UPDATE foo SET baz = -223 * 4.2;
+SELECT * FROM foo;
+-- msg: CREATE TABLE 1
+-- msg: INSERT 1
+-- msg: UPDATE 1
+-- BAZ: -936.6
+
+CREATE TABLE foo (baz FLOAT);
+INSERT INTO foo (baz) VALUES (-123);
+UPDATE foo SET baz = baz * 4.2;
+SELECT * FROM foo;
+-- msg: CREATE TABLE 1
+-- msg: INSERT 1
+-- msg: UPDATE 1
+-- BAZ: -516.6

--- a/vsql/insert.v
+++ b/vsql/insert.v
@@ -24,7 +24,8 @@ fn (mut c Connection) insert(stmt InsertStmt) ?Result {
 	for i, column in stmt.columns {
 		column_name := identifier_name(column.name)
 		table_column := table.column(column_name) ?
-		value := cast('for column $column_name', stmt.values[i] as Value, table_column.typ) ?
+		raw_value := eval_as_value(c, Row{}, stmt.values[i]) ?
+		value := cast('for column $column_name', raw_value, table_column.typ) ?
 
 		if value.typ.typ == .is_null && table_column.not_null {
 			return sqlstate_23502('column $column_name')

--- a/vsql/row.v
+++ b/vsql/row.v
@@ -87,3 +87,30 @@ fn (r Row) get(name string) ?Value {
 		return error('no such column $name')
 	}
 }
+
+// new_empty_row is used internally to generate a row with zero values for all
+// the types in a Row. This is used for testing expressions without needing the
+// actual row.
+fn new_empty_row(columns []Column) Row {
+	mut r := Row{}
+	for col in columns {
+		mut v := Value{}
+		match col.typ.typ {
+			.is_null {
+				v = new_null_value()
+			}
+			.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint {
+				v = new_double_precision_value(0)
+			}
+			.is_boolean {
+				v = new_boolean_value(false)
+			}
+			.is_character, .is_varchar {
+				v = new_varchar_value('', 0)
+			}
+		}
+		r.data[col.name] = v
+	}
+
+	return r
+}


### PR DESCRIPTION
Both INSERT and UPDATE would only accept Value for any expression, now
any expression can be provided. Including referencing existing columns
in a SET clause.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/32)
<!-- Reviewable:end -->
