### PR TITLE
Prepared statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ no dependencies.
   - [Server](#server)
   - [Custom Functions](#custom-functions)
   - [Virtual Tables](#virtual-tables)
+  - [Prepared Statements](https://github.com/elliotchance/vsql/blob/main/docs/prepared-statements.rst)
 - [FAQ](https://github.com/elliotchance/vsql/blob/main/docs/faq.rst)
 - SQL Commands
   - [CREATE TABLE](https://github.com/elliotchance/vsql/blob/main/docs/create-table.rst)
@@ -25,7 +26,7 @@ no dependencies.
   - [Operators](https://github.com/elliotchance/vsql/blob/main/docs/operators.rst)
   - [SQLSTATE (Errors)](https://github.com/elliotchance/vsql/blob/main/docs/sqlstate.rst)
 - [Development](https://github.com/elliotchance/vsql/blob/main/docs/development.rst)
-- [Testing](#testing)
+- [Testing](https://github.com/elliotchance/vsql/blob/main/docs/testing.rst)
 
 Usage
 -----
@@ -187,36 +188,3 @@ for row in result {
 The callback for the virtual table will be called repeatedly until `t.done()` is
 invoked, even if zero rows are provided in an iteration. All data will be thrown
 away between subsequent `SELECT` operations.
-
-Testing
--------
-
-All tests are in the `tests/` directory and each file contains individual tests
-separated by an empty line:
-
-```sql
-/* setup */
-CREATE TABLE t1 (x FLOAT);
-INSERT INTO t1 (x) VALUES (0);
-
-SELECT 1 FROM t1;
-SELECT *
-FROM foo;
--- COL1: 1
--- error 42P01: no such table: FOO
-
-SELECT 2 FROM t1;
-SELECT 3 FROM t1;
--- COL1: 2
--- COL1: 3
-```
-
-This describes two tests where each test is given an a brand new database (ie.
-no tables are carried between tests).
-
-- An optional `/* setup */` can be placed at the top of the file to be run
-before each test.
-- All SQL statements are executed and each of the results collected and compared
-to the comment immediately below.
-- Errors will be in the form of `error SQLSTATE: message`.
-- A statement can span multiple lines but must me terminated by a `;`.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,6 +1,8 @@
 Development
 ===========
 
+This page is aimed to developers of vsql.
+
 .. contents::
 
 Parser & SQL Grammar
@@ -34,3 +36,9 @@ After making changes to `grammar.bnf` you will need to run:
 
 Now, when running `v test .` you may receive errors for missing ``parse_``
 functions, you should implement those now.
+
+Testing
+-------
+
+vsql is tested exclusively with SQL test files. See
+`Testing <https://github.com/elliotchance/vsql/blob/main/docs/testing.rst>`_.

--- a/docs/prepared-statements.rst
+++ b/docs/prepared-statements.rst
@@ -1,0 +1,24 @@
+Prepared Statements
+===================
+
+A prepared statement is compiled and validated, but not executed. It can then be
+executed with a set of host parameters (in the form of ``:name``) to be
+substituted into the statement. Each invocation requires all host parameters to
+be passed in.
+
+The ``Connection`` provides a ``prepare()`` function, which can be subsequently
+executed using ``query()`` with some (or none) host parameters:
+
+.. code-block:: sh
+
+    stmt := db.prepare('SELECT * FROM people WHERE first_name = :name') ?
+
+    for name in ['Bob', 'Jane'] {
+        result := stmt.query({
+            'name': new_varchar_value(name)
+        }) ?
+
+        for row in result {
+            println(row.get_string('FIRST_NAME') ?)
+        }
+    }

--- a/docs/sqlstate.rst
+++ b/docs/sqlstate.rst
@@ -140,6 +140,17 @@ SQLSTATE
   DELETE FROM foo;
   -- error 42P01: no such table: FOO
 
+``42P02`` parameter does not exist
+----------------------------------
+
+**Examples**
+
+.. code-block:: sql
+
+  CREATE TABLE t1 (x FLOAT);
+  INSERT INTO t1 (x) VALUES (:foo);
+  -- error 42P02: no such parameter: foo
+
 ``42P07`` table already exists
 ------------------------------
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,0 +1,76 @@
+.. contents::
+
+vsql is tested exclusively with SQL test files. This page describes how to write
+tests and optional functionality you might need.
+
+Test Files
+----------
+
+All tests are in the ``tests/`` directory and each file contains individual
+tests separated by an empty line:
+
+.. code-block:: sql
+
+   SELECT 1 FROM t1;
+   SELECT *
+   FROM foo;
+   -- COL1: 1
+   -- error 42P01: no such table: FOO
+   
+   SELECT 2 FROM t1;
+   SELECT 3 FROM t1;
+   -- COL1: 2
+   -- COL1: 3
+
+This describes two tests where each test is given an a brand new database (ie.
+no tables are carried between tests).
+
+All SQL statements are executed and each of the results collected and compared
+to the comment immediately below.
+
+A statement can span multiple lines but must me terminated by a `;`.
+
+Errors will be in the form of ``error SQLSTATE: message``.
+
+Setup
+-----
+
+An optional ``/* setup */`` can be placed at the top of the file to be run
+before each test:
+
+.. code-block:: sql
+
+   /* setup */
+   CREATE TABLE t1 (x FLOAT);
+   INSERT INTO t1 (x) VALUES (0);
+   
+   SELECT 1 FROM t1;
+   -- COL1: 1
+   
+   SELECT 2 FROM t1;
+   -- COL1: 2
+
+Host Parameters
+---------------
+
+Host parameters can be set with the ``/* set name value */`` and only exist for
+the lifetime of a single test:
+
+.. code-block:: sql
+
+   /* setup */
+   CREATE TABLE t1 (x FLOAT);
+   
+   INSERT INTO t1 (x) VALUES (:foo);
+   -- error 42P02: parameter does not exist: foo
+   
+   /* set foo 2 */
+   INSERT INTO t1 (x) VALUES (:foo);
+   SELECT * FROM t1;
+   -- msg: INSERT 1
+   -- X: 2
+
+There are slightly different forms depending on the type of the host parameter:
+
+- ``/* set a 123 */`` for numeric values.
+- ``/* set b 'foo' */`` for string values.

--- a/generate-grammar.py
+++ b/generate-grammar.py
@@ -484,7 +484,7 @@ def parse_tree(text):
     table = []
     for i, token in enumerate(tokens):
         if token == '(' or token == ')' or token == ',' or token == '.' or \
-            token == '+' or token == '-' or token == '||':
+            token == '+' or token == '-' or token == '||' or token == ':':
             table.append(EarleyColumn(i, token, token))
         elif token == '' or token.isupper():
             table.append(EarleyColumn(i, token, token))

--- a/grammar.bnf
+++ b/grammar.bnf
@@ -192,11 +192,12 @@
     <unsigned numeric literal>
   | <general literal>
 
-<unsigned value specification> /* Value */ ::=
-    <unsigned literal>
+<unsigned value specification> /* Expr */ ::=
+    <unsigned literal>              -> value_to_expr
+  | <general value specification>
 
 <nonparenthesized value expression primary> /* Expr */ ::=
-    <unsigned value specification>   -> value_to_expr
+    <unsigned value specification>
   | <column reference>               -> identifier_to_expr
   | <routine invocation>
 
@@ -616,3 +617,15 @@
 
 <SQL argument> /* Expr */ ::=
     <value expression>
+
+<general value specification> /* Expr */ ::=
+    <host parameter specification>
+
+<host parameter specification> /* Expr */ ::=
+    <host parameter name>
+
+<host parameter name> /* Expr */ ::=
+    <colon> <identifier>   -> host_parameter_name
+
+<colon> ::=
+  ":"

--- a/tests/parameters.sql
+++ b/tests/parameters.sql
@@ -1,0 +1,49 @@
+/* setup */
+CREATE TABLE t1 (x FLOAT);
+
+INSERT INTO t1 (x) VALUES (:foo);
+-- error 42P02: parameter does not exist: foo
+
+/* set foo 2 */
+INSERT INTO t1 (x) VALUES (:foo);
+SELECT * FROM t1;
+-- msg: INSERT 1
+-- X: 2
+
+/* set foo 'hello' */
+INSERT INTO t1 (x) VALUES (:foo);
+-- error 42804: data type mismatch for column X: expected DOUBLE PRECISION but got CHARACTER VARYING
+
+/* set foo 'hello' */
+CREATE TABLE t2 (x VARCHAR(10));
+INSERT INTO t2 (x) VALUES (:foo);
+SELECT * FROM t2;
+-- msg: CREATE TABLE 1
+-- msg: INSERT 1
+-- X: hello
+
+UPDATE t1 SET x = :foo;
+-- error 42P02: parameter does not exist: foo
+
+/* set foo 321 */
+INSERT INTO t1 (x) VALUES (100);
+UPDATE t1 SET x = :foo;
+SELECT * FROM t1;
+-- msg: INSERT 1
+-- msg: UPDATE 1
+-- X: 321
+
+DELETE FROM t1 WHERE x = :foo;
+-- msg: DELETE 0
+
+INSERT INTO t1 (x) VALUES (200);
+DELETE FROM t1 WHERE x = :foo;
+-- msg: INSERT 1
+-- error 42P02: parameter does not exist: foo
+
+/* set foo 100 */
+INSERT INTO t1 (x) VALUES (100);
+DELETE FROM t1 WHERE x = :foo;
+SELECT * FROM t1;
+-- msg: INSERT 1
+-- msg: DELETE 1

--- a/vsql/ast.v
+++ b/vsql/ast.v
@@ -6,8 +6,8 @@ module vsql
 type Stmt = CreateTableStmt | DeleteStmt | DropTableStmt | InsertStmt | SelectStmt | UpdateStmt
 
 // All possible expression entities.
-type Expr = BinaryExpr | CallExpr | Identifier | NamedExpr | NoExpr | NullExpr | UnaryExpr |
-	Value
+type Expr = BinaryExpr | CallExpr | Identifier | NamedExpr | NoExpr | NullExpr | Parameter |
+	UnaryExpr | Value
 
 // CREATE TABLE ...
 struct CreateTableStmt {
@@ -105,3 +105,8 @@ struct DerivedColumn {
 type AsteriskExpr = bool
 
 type SelectList = AsteriskExpr | []DerivedColumn
+
+// Parameter is :foo. The colon is not included in the name.
+struct Parameter {
+	name string
+}

--- a/vsql/connection.v
+++ b/vsql/connection.v
@@ -3,6 +3,7 @@
 
 module vsql
 
+[heap]
 struct Connection {
 mut:
 	storage        FileStorage
@@ -19,29 +20,16 @@ pub fn open(path string) ?Connection {
 	return conn
 }
 
-pub fn (mut c Connection) query(sql string) ?Result {
+pub fn (mut c Connection) prepare(sql string) ?PreparedStmt {
 	stmt := parse(sql) ?
 
-	match stmt {
-		CreateTableStmt {
-			return c.create_table(stmt)
-		}
-		DeleteStmt {
-			return c.delete(stmt)
-		}
-		DropTableStmt {
-			return c.drop_table(stmt)
-		}
-		InsertStmt {
-			return c.insert(stmt)
-		}
-		SelectStmt {
-			return c.query_select(stmt)
-		}
-		UpdateStmt {
-			return c.update(stmt)
-		}
-	}
+	return PreparedStmt{stmt, &c}
+}
+
+pub fn (mut c Connection) query(sql string) ?Result {
+	mut prepared := c.prepare(sql) ?
+
+	return prepared.query(map[string]Value{})
 }
 
 pub fn (mut c Connection) register_func(func Func) ? {

--- a/vsql/create_table.v
+++ b/vsql/create_table.v
@@ -4,7 +4,7 @@ module vsql
 
 // TODO(elliotchance): A table is allowed to have zero columns.
 
-fn (mut c Connection) create_table(stmt CreateTableStmt) ?Result {
+fn execute_create_table(mut c Connection, stmt CreateTableStmt) ?Result {
 	table_name := identifier_name(stmt.table_name)
 
 	if table_name in c.storage.tables {

--- a/vsql/delete.v
+++ b/vsql/delete.v
@@ -2,7 +2,7 @@
 
 module vsql
 
-fn (mut c Connection) delete(stmt DeleteStmt) ?Result {
+fn execute_delete(mut c Connection, stmt DeleteStmt, params map[string]Value) ?Result {
 	table_name := identifier_name(stmt.table_name)
 
 	if table_name !in c.storage.tables {
@@ -16,7 +16,7 @@ fn (mut c Connection) delete(stmt DeleteStmt) ?Result {
 	for row in rows {
 		mut ok := true
 		if stmt.where !is NoExpr {
-			ok = eval_as_bool(c, row, stmt.where) ?
+			ok = eval_as_bool(c, row, stmt.where, params) ?
 		}
 
 		if ok {

--- a/vsql/drop_table.v
+++ b/vsql/drop_table.v
@@ -2,7 +2,7 @@
 
 module vsql
 
-fn (mut c Connection) drop_table(stmt DropTableStmt) ?Result {
+fn execute_drop_table(mut c Connection, stmt DropTableStmt) ?Result {
 	table_name := identifier_name(stmt.table_name)
 
 	if table_name !in c.storage.tables {

--- a/vsql/earley.v
+++ b/vsql/earley.v
@@ -346,7 +346,7 @@ fn tokenize_earley_columns(tokens []Token) []EarleyColumn {
 			table << new_earley_column(i + 1, v, v)
 		} else if v == '(' || v == ')' || v == ',' || v == '=' || v == '<>' || v == '.' || v == '+'
 			|| v == '-' || v == '*' || v == '/' || v == '>' || v == '<' || v == '>=' || v == '<='
-			|| v == '||' {
+			|| v == '||' || v == ':' {
 			table << new_earley_column(i + 1, v, v)
 		} else {
 			table << new_earley_column(i + 1, '^identifier', v)

--- a/vsql/grammar.v
+++ b/vsql/grammar.v
@@ -140,6 +140,9 @@ fn get_grammar() map[string]EarleyRule {
 	mut rule_character_value_expression_ := &EarleyRule{
 		name: '<character value expression>'
 	}
+	mut rule_colon_ := &EarleyRule{
+		name: '<colon>'
+	}
 	mut rule_column_constraint_definition_ := &EarleyRule{
 		name: '<column constraint definition>'
 	}
@@ -368,11 +371,23 @@ fn get_grammar() map[string]EarleyRule {
 	mut rule_general_literal_ := &EarleyRule{
 		name: '<general literal>'
 	}
+	mut rule_general_value_specification_ := &EarleyRule{
+		name: '<general value specification>'
+	}
 	mut rule_greater_than_operator_ := &EarleyRule{
 		name: '<greater than operator>'
 	}
 	mut rule_greater_than_or_equals_operator_ := &EarleyRule{
 		name: '<greater than or equals operator>'
+	}
+	mut rule_host_parameter_name_1_ := &EarleyRule{
+		name: '<host parameter name: 1>'
+	}
+	mut rule_host_parameter_name_ := &EarleyRule{
+		name: '<host parameter name>'
+	}
+	mut rule_host_parameter_specification_ := &EarleyRule{
+		name: '<host parameter specification>'
 	}
 	mut rule_identifier_body_ := &EarleyRule{
 		name: '<identifier body>'
@@ -439,9 +454,6 @@ fn get_grammar() map[string]EarleyRule {
 	}
 	mut rule_natural_logarithm_ := &EarleyRule{
 		name: '<natural logarithm>'
-	}
-	mut rule_nonparenthesized_value_expression_primary_1_ := &EarleyRule{
-		name: '<nonparenthesized value expression primary: 1>'
 	}
 	mut rule_nonparenthesized_value_expression_primary_2_ := &EarleyRule{
 		name: '<nonparenthesized value expression primary: 2>'
@@ -784,6 +796,9 @@ fn get_grammar() map[string]EarleyRule {
 	}
 	mut rule_unsigned_numeric_literal_ := &EarleyRule{
 		name: '<unsigned numeric literal>'
+	}
+	mut rule_unsigned_value_specification_1_ := &EarleyRule{
+		name: '<unsigned value specification: 1>'
 	}
 	mut rule_unsigned_value_specification_ := &EarleyRule{
 		name: '<unsigned value specification>'
@@ -1461,6 +1476,13 @@ fn get_grammar() map[string]EarleyRule {
 	rule_character_value_expression_.productions << EarleyProduction{[
 		EarleyRuleOrString{
 			rule: rule_character_factor_
+		},
+	]}
+
+	rule_colon_.productions << EarleyProduction{[
+		EarleyRuleOrString{
+			str: ':'
+			rule: 0
 		},
 	]}
 
@@ -2204,6 +2226,12 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
+	rule_general_value_specification_.productions << EarleyProduction{[
+		EarleyRuleOrString{
+			rule: rule_host_parameter_specification_
+		},
+	]}
+
 	rule_greater_than_operator_.productions << EarleyProduction{[
 		EarleyRuleOrString{
 			str: '>'
@@ -2215,6 +2243,27 @@ fn get_grammar() map[string]EarleyRule {
 		EarleyRuleOrString{
 			str: '>='
 			rule: 0
+		},
+	]}
+
+	rule_host_parameter_name_1_.productions << EarleyProduction{[
+		EarleyRuleOrString{
+			rule: rule_colon_
+		},
+		EarleyRuleOrString{
+			rule: rule_identifier_
+		},
+	]}
+
+	rule_host_parameter_name_.productions << EarleyProduction{[
+		EarleyRuleOrString{
+			rule: rule_host_parameter_name_1_
+		},
+	]}
+
+	rule_host_parameter_specification_.productions << EarleyProduction{[
+		EarleyRuleOrString{
+			rule: rule_host_parameter_name_
 		},
 	]}
 
@@ -2392,12 +2441,6 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
-	rule_nonparenthesized_value_expression_primary_1_.productions << EarleyProduction{[
-		EarleyRuleOrString{
-			rule: rule_unsigned_value_specification_
-		},
-	]}
-
 	rule_nonparenthesized_value_expression_primary_2_.productions << EarleyProduction{[
 		EarleyRuleOrString{
 			rule: rule_column_reference_
@@ -2406,7 +2449,7 @@ fn get_grammar() map[string]EarleyRule {
 
 	rule_nonparenthesized_value_expression_primary_.productions << EarleyProduction{[
 		EarleyRuleOrString{
-			rule: rule_nonparenthesized_value_expression_primary_1_
+			rule: rule_unsigned_value_specification_
 		},
 	]}
 	rule_nonparenthesized_value_expression_primary_.productions << EarleyProduction{[
@@ -3506,9 +3549,20 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
-	rule_unsigned_value_specification_.productions << EarleyProduction{[
+	rule_unsigned_value_specification_1_.productions << EarleyProduction{[
 		EarleyRuleOrString{
 			rule: rule_unsigned_literal_
+		},
+	]}
+
+	rule_unsigned_value_specification_.productions << EarleyProduction{[
+		EarleyRuleOrString{
+			rule: rule_unsigned_value_specification_1_
+		},
+	]}
+	rule_unsigned_value_specification_.productions << EarleyProduction{[
+		EarleyRuleOrString{
+			rule: rule_general_value_specification_
 		},
 	]}
 
@@ -4090,6 +4144,7 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<character string type: 7>'] = rule_character_string_type_7_
 	rules['<character string type>'] = rule_character_string_type_
 	rules['<character value expression>'] = rule_character_value_expression_
+	rules['<colon>'] = rule_colon_
 	rules['<column constraint definition>'] = rule_column_constraint_definition_
 	rules['<column constraint: 1>'] = rule_column_constraint_1_
 	rules['<column constraint>'] = rule_column_constraint_
@@ -4166,8 +4221,12 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<from constructor: 1>'] = rule_from_constructor_1_
 	rules['<from constructor>'] = rule_from_constructor_
 	rules['<general literal>'] = rule_general_literal_
+	rules['<general value specification>'] = rule_general_value_specification_
 	rules['<greater than operator>'] = rule_greater_than_operator_
 	rules['<greater than or equals operator>'] = rule_greater_than_or_equals_operator_
+	rules['<host parameter name: 1>'] = rule_host_parameter_name_1_
+	rules['<host parameter name>'] = rule_host_parameter_name_
+	rules['<host parameter specification>'] = rule_host_parameter_specification_
 	rules['<identifier body>'] = rule_identifier_body_
 	rules['<identifier chain>'] = rule_identifier_chain_
 	rules['<identifier start>'] = rule_identifier_start_
@@ -4190,7 +4249,6 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<modulus expression>'] = rule_modulus_expression_
 	rules['<natural logarithm: 1>'] = rule_natural_logarithm_1_
 	rules['<natural logarithm>'] = rule_natural_logarithm_
-	rules['<nonparenthesized value expression primary: 1>'] = rule_nonparenthesized_value_expression_primary_1_
 	rules['<nonparenthesized value expression primary: 2>'] = rule_nonparenthesized_value_expression_primary_2_
 	rules['<nonparenthesized value expression primary>'] = rule_nonparenthesized_value_expression_primary_
 	rules['<not equals operator>'] = rule_not_equals_operator_
@@ -4305,6 +4363,7 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<unsigned integer>'] = rule_unsigned_integer_
 	rules['<unsigned literal>'] = rule_unsigned_literal_
 	rules['<unsigned numeric literal>'] = rule_unsigned_numeric_literal_
+	rules['<unsigned value specification: 1>'] = rule_unsigned_value_specification_1_
 	rules['<unsigned value specification>'] = rule_unsigned_value_specification_
 	rules['<update source>'] = rule_update_source_
 	rules['<update statement: searched: 1>'] = rule_update_statement_searched_1_
@@ -4615,6 +4674,9 @@ fn parse_ast(node EarleyNode) ?[]EarleyValue {
 				EarleyValue(parse_from_constructor(children[1] as []Identifier, children[3] as []Expr) ?),
 			]
 		}
+		'<host parameter name: 1>' {
+			children = [EarleyValue(parse_host_parameter_name(children[1] as Identifier) ?)]
+		}
 		'<insert statement: 1>' {
 			children = [
 				EarleyValue(parse_insert_statement(children[2] as Identifier, children[3] as InsertStmt) ?),
@@ -4628,9 +4690,6 @@ fn parse_ast(node EarleyNode) ?[]EarleyValue {
 		}
 		'<natural logarithm: 1>' {
 			children = [EarleyValue(parse_ln(children[2] as Expr) ?)]
-		}
-		'<nonparenthesized value expression primary: 1>' {
-			children = [EarleyValue(parse_value_to_expr(children[0] as Value) ?)]
 		}
 		'<nonparenthesized value expression primary: 2>' {
 			children = [EarleyValue(parse_identifier_to_expr(children[0] as Identifier) ?)]
@@ -4781,6 +4840,9 @@ fn parse_ast(node EarleyNode) ?[]EarleyValue {
 		}
 		'<trigonometric function: 1>' {
 			children = [EarleyValue(parse_trig_func(children[0] as string, children[2] as Expr) ?)]
+		}
+		'<unsigned value specification: 1>' {
+			children = [EarleyValue(parse_value_to_expr(children[0] as Value) ?)]
 		}
 		'<update statement: searched: 1>' {
 			children = [

--- a/vsql/insert.v
+++ b/vsql/insert.v
@@ -2,7 +2,7 @@
 
 module vsql
 
-fn (mut c Connection) insert(stmt InsertStmt) ?Result {
+fn execute_insert(mut c Connection, stmt InsertStmt, params map[string]Value) ?Result {
 	mut row := Row{
 		data: map[string]Value{}
 	}
@@ -24,7 +24,7 @@ fn (mut c Connection) insert(stmt InsertStmt) ?Result {
 	for i, column in stmt.columns {
 		column_name := identifier_name(column.name)
 		table_column := table.column(column_name) ?
-		raw_value := eval_as_value(c, Row{}, stmt.values[i]) ?
+		raw_value := eval_as_value(c, Row{}, stmt.values[i], params) ?
 		value := cast('for column $column_name', raw_value, table_column.typ) ?
 
 		if value.typ.typ == .is_null && table_column.not_null {

--- a/vsql/lexer.v
+++ b/vsql/lexer.v
@@ -8,6 +8,7 @@ module vsql
 enum TokenKind {
 	eof // End of file
 	asterisk // <asterisk> ::= *
+	colon // <colon> ::= :
 	comma // <comma> ::= ,
 	concatenation_operator // <concatenation operator> ::= ||
 	equals_operator // <equals operator> ::= =
@@ -152,6 +153,7 @@ fn tokenize(sql string) []Token {
 			`=`: TokenKind.equals_operator
 			`>`: TokenKind.greater_than_operator
 			`.`: TokenKind.period
+			`:`: TokenKind.colon
 		}
 		for op, tk in single {
 			if cs[i] == op {

--- a/vsql/parse.v
+++ b/vsql/parse.v
@@ -402,3 +402,7 @@ fn parse_empty_exprs() ?[]Expr {
 fn parse_routine_invocation(name Identifier, args []Expr) ?Expr {
 	return CallExpr{name.name, args}
 }
+
+fn parse_host_parameter_name(name Identifier) ?Expr {
+	return Parameter{name.name}
+}

--- a/vsql/prepare.v
+++ b/vsql/prepare.v
@@ -1,0 +1,37 @@
+// prepare.v is for prepared statements. A prepared statement is compiled and
+// validated, but not executed. It can then be executed with a set of host
+// parameters to be substituted into the statement. Each invocation requires all
+// host parameters to be passed in.
+
+module vsql
+
+struct PreparedStmt {
+	stmt Stmt
+mut:
+	c &Connection
+}
+
+pub fn (mut p PreparedStmt) query(params map[string]Value) ?Result {
+	stmt := p.stmt
+
+	match stmt {
+		CreateTableStmt {
+			return execute_create_table(mut p.c, stmt)
+		}
+		DeleteStmt {
+			return execute_delete(mut p.c, stmt, params)
+		}
+		DropTableStmt {
+			return execute_drop_table(mut p.c, stmt)
+		}
+		InsertStmt {
+			return execute_insert(mut p.c, stmt, params)
+		}
+		SelectStmt {
+			return execute_select(mut p.c, stmt, params)
+		}
+		UpdateStmt {
+			return execute_update(mut p.c, stmt, params)
+		}
+	}
+}

--- a/vsql/select.v
+++ b/vsql/select.v
@@ -2,7 +2,7 @@
 
 module vsql
 
-fn (mut c Connection) query_select(stmt SelectStmt) ?Result {
+fn execute_select(mut c Connection, stmt SelectStmt, params map[string]Value) ?Result {
 	// Find all rows first.
 	mut all_rows := []Row{}
 	mut exprs := stmt.exprs
@@ -46,7 +46,7 @@ fn (mut c Connection) query_select(stmt SelectStmt) ?Result {
 				all_rows = all_rows[..stmt.fetch]
 			}
 		} else {
-			all_rows = where(c, all_rows, false, stmt.where, stmt.fetch) ?
+			all_rows = where(c, all_rows, false, stmt.where, stmt.fetch, params) ?
 		}
 	} else {
 		return sqlstate_42p01(table_name)
@@ -73,7 +73,7 @@ fn (mut c Connection) query_select(stmt SelectStmt) ?Result {
 				column_names << column_name
 			}
 
-			data[column_name] = eval_as_value(c, row, expr.expr) ?
+			data[column_name] = eval_as_value(c, row, expr.expr, params) ?
 			col_num++
 		}
 

--- a/vsql/sqlstate.v
+++ b/vsql/sqlstate.v
@@ -170,3 +170,19 @@ fn sqlstate_42883(function_name string) IError {
 		function_name: function_name
 	}
 }
+
+// Undefined parameter
+struct SQLState42P02 {
+	msg  string
+	code int
+pub:
+	parameter_name string
+}
+
+fn sqlstate_42p02(parameter_name string) IError {
+	return SQLState42P02{
+		code: sqlstate_to_int('42P02')
+		msg: 'parameter does not exist: $parameter_name'
+		parameter_name: parameter_name
+	}
+}

--- a/vsql/type.v
+++ b/vsql/type.v
@@ -34,7 +34,9 @@ fn (t SQLType) str() string {
 }
 
 fn new_type(name string, size int) Type {
-	return match name {
+	name_without_size := name.split('(')[0]
+
+	return match name_without_size {
 		'BIGINT' {
 			Type{.is_bigint, size}
 		}
@@ -60,7 +62,7 @@ fn new_type(name string, size int) Type {
 			Type{.is_smallint, size}
 		}
 		else {
-			panic(name)
+			panic(name_without_size)
 			Type{}
 		}
 	}

--- a/vsql/where.v
+++ b/vsql/where.v
@@ -3,10 +3,10 @@
 module vsql
 
 // fetch: -1 to ignore, otherwise the max records to return.
-fn where(conn Connection, rows []Row, inverse bool, expr Expr, fetch int) ?[]Row {
+fn where(conn Connection, rows []Row, inverse bool, expr Expr, fetch int, params map[string]Value) ?[]Row {
 	mut new_rows := []Row{}
 	for row in rows {
-		mut ok := eval_as_bool(conn, row, expr) ?
+		mut ok := eval_as_bool(conn, row, expr, params) ?
 		if inverse {
 			ok = !ok
 		}


### PR DESCRIPTION
A prepared statement is compiled and validated, but not executed. It
can then be executed with a set of host parameters (in the form of
":name") to be substituted into the statement. Each invocation
requires all host parameters to be passed in.

The Connection now offers a prepare() function, which can be
subsequently executed using query() with some (or none) host
parameters. The existing Connection.query() now simply acts as a proxy
for a prepared statement without any host parameters.

Added SQLSTATE 42P02 "parameter does not exist".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/34)
<!-- Reviewable:end -->
