### PR TITLE
Added a query cache

### DIFF
--- a/grammar.bnf
+++ b/grammar.bnf
@@ -578,6 +578,7 @@
 
 <simple value specification> /* Expr */ ::=
     <literal>
+  | <host parameter name>
 
 <literal> /* Expr */ ::=
     <signed numeric literal>

--- a/tests/offset-fetch.sql
+++ b/tests/offset-fetch.sql
@@ -44,3 +44,11 @@ FETCH FIRST 2 ROWS ONLY;
 SELECT * FROM t1
 OFFSET 10 ROWS
 FETCH FIRST 2 ROWS ONLY;
+
+/* set offset_num 1 */
+/* set row_num 2 */
+SELECT * FROM t1
+OFFSET :offset_num ROW
+FETCH FIRST :row_num ROWS ONLY;
+-- X: 2
+-- X: 3

--- a/vsql/ast.v
+++ b/vsql/ast.v
@@ -38,8 +38,8 @@ struct SelectStmt {
 	exprs  SelectList
 	from   string
 	where  Expr
-	offset int
-	fetch  int // -1 to ignore
+	offset Expr
+	fetch  Expr
 }
 
 // UPDATE ...

--- a/vsql/earley.v
+++ b/vsql/earley.v
@@ -226,14 +226,8 @@ fn complete(mut col EarleyColumn, state EarleyState) {
 	}
 }
 
-fn parse(sql string) ?Stmt {
-	mut new_tokens := tokenize(sql.trim(';'))
-
-	// Strip EOF
-	new_tokens = new_tokens[..new_tokens.len - 1]
-
-	mut columns := tokenize_earley_columns(new_tokens)
-
+fn parse(tokens []Token) ?Stmt {
+	mut columns := tokenize_earley_columns(tokens)
 	mut grammar := get_grammar()
 
 	q0 := parse_earley(grammar['<preparable statement>'], mut columns) ?

--- a/vsql/grammar.v
+++ b/vsql/grammar.v
@@ -3152,6 +3152,11 @@ fn get_grammar() map[string]EarleyRule {
 			rule: rule_literal_
 		},
 	]}
+	rule_simple_value_specification_.productions << EarleyProduction{[
+		EarleyRuleOrString{
+			rule: rule_host_parameter_name_
+		},
+	]}
 
 	rule_solidus_.productions << EarleyProduction{[
 		EarleyRuleOrString{

--- a/vsql/lexer.v
+++ b/vsql/lexer.v
@@ -6,7 +6,6 @@ module vsql
 // Except for the eof and the keywords, the other tokens use the names described
 // in the SQL standard.
 enum TokenKind {
-	eof // End of file
 	asterisk // <asterisk> ::= *
 	colon // <colon> ::= :
 	comma // <comma> ::= ,
@@ -78,7 +77,7 @@ pub:
 
 fn tokenize(sql string) []Token {
 	mut tokens := []Token{}
-	cs := sql.runes()
+	cs := sql.trim(';').runes()
 	mut i := 0
 
 	next: for i < cs.len {
@@ -184,8 +183,6 @@ fn tokenize(sql string) []Token {
 		}
 	}
 
-	tokens << Token{TokenKind.eof, ''}
-
 	return tokens
 }
 
@@ -198,29 +195,4 @@ fn is_identifier_char(c byte, is_not_first bool) bool {
 	}
 
 	return yes
-}
-
-fn precedence(tk TokenKind) int {
-	return match tk {
-		.asterisk, .solidus {
-			2
-		}
-		.plus_sign, .minus_sign {
-			3
-		}
-		.equals_operator, .not_equals_operator, .less_than_operator, .less_than_or_equals_operator,
-		.greater_than_operator, .greater_than_or_equals_operator {
-			4
-		}
-		.keyword_and {
-			6
-		}
-		.keyword_or {
-			7
-		}
-		else {
-			panic(tk)
-			0
-		}
-	}
 }

--- a/vsql/parse.v
+++ b/vsql/parse.v
@@ -9,7 +9,7 @@ fn parse_binary_expr(left Expr, op string, right Expr) ?Expr {
 }
 
 fn parse_query_specification(select_list SelectList, table_expression TableExpression) ?SelectStmt {
-	return SelectStmt{select_list, table_expression.from_clause.name, table_expression.where_clause, 0, -1}
+	return SelectStmt{select_list, table_expression.from_clause.name, table_expression.where_clause, NoExpr{}, NoExpr{}}
 }
 
 fn parse_select_sublist(column DerivedColumn) ?SelectList {
@@ -347,51 +347,32 @@ fn parse_query_expression(body SelectStmt) ?Stmt {
 }
 
 fn parse_query_expression_offset(body SelectStmt, offset Expr) ?Stmt {
-	mut offset_int := 0
-	if offset is Value {
-		offset_int = int(offset.f64_value)
-	}
-
 	return SelectStmt{
 		exprs: body.exprs
 		from: body.from
 		where: body.where
-		offset: offset_int
-		fetch: -1
+		offset: offset
+		fetch: NoExpr{}
 	}
 }
 
 fn parse_query_expression_fetch(body SelectStmt, fetch Expr) ?Stmt {
-	mut fetch_int := -1
-	if fetch is Value {
-		fetch_int = int(fetch.f64_value)
-	}
-
 	return SelectStmt{
 		exprs: body.exprs
 		from: body.from
 		where: body.where
-		fetch: fetch_int
+		offset: NoExpr{}
+		fetch: fetch
 	}
 }
 
 fn parse_query_expression_offset_fetch(body SelectStmt, offset Expr, fetch Expr) ?Stmt {
-	mut offset_int := 0
-	if offset is Value {
-		offset_int = int(offset.f64_value)
-	}
-
-	mut fetch_int := -1
-	if fetch is Value {
-		fetch_int = int(fetch.f64_value)
-	}
-
 	return SelectStmt{
 		exprs: body.exprs
 		from: body.from
 		where: body.where
-		offset: offset_int
-		fetch: fetch_int
+		offset: offset
+		fetch: fetch
 	}
 }
 

--- a/vsql/prepare.v
+++ b/vsql/prepare.v
@@ -7,6 +7,10 @@ module vsql
 
 struct PreparedStmt {
 	stmt Stmt
+	// params can be set on the statement and will be merged with the extra
+	// params at execution time. If name collisions occur, the params provided
+	// at execution time will take precedence.
+	params map[string]Value
 mut:
 	c &Connection
 }
@@ -14,24 +18,31 @@ mut:
 pub fn (mut p PreparedStmt) query(params map[string]Value) ?Result {
 	stmt := p.stmt
 
+	mut all_params := params.clone()
+	for k, v in p.params {
+		if k !in all_params {
+			all_params[k] = v
+		}
+	}
+
 	match stmt {
 		CreateTableStmt {
 			return execute_create_table(mut p.c, stmt)
 		}
 		DeleteStmt {
-			return execute_delete(mut p.c, stmt, params)
+			return execute_delete(mut p.c, stmt, all_params)
 		}
 		DropTableStmt {
 			return execute_drop_table(mut p.c, stmt)
 		}
 		InsertStmt {
-			return execute_insert(mut p.c, stmt, params)
+			return execute_insert(mut p.c, stmt, all_params)
 		}
 		SelectStmt {
-			return execute_select(mut p.c, stmt, params)
+			return execute_select(mut p.c, stmt, all_params)
 		}
 		UpdateStmt {
-			return execute_update(mut p.c, stmt, params)
+			return execute_update(mut p.c, stmt, all_params)
 		}
 	}
 }

--- a/vsql/query_cache.v
+++ b/vsql/query_cache.v
@@ -1,0 +1,98 @@
+// query_cache.v provides tooling to cache previously parsed prepared
+// statements. This is becuase parsing a statement is extremely expensive with
+// the current Earley implementation and many queries (excluding values) are
+// used more than once.
+//
+// The query cache is made more useful by the fact it can turn any existing
+// query into a prepared statement so that cache works in all cases.
+
+module vsql
+
+struct QueryCache {
+mut:
+	stmts map[string]Stmt
+}
+
+fn new_query_cache() &QueryCache {
+	return &QueryCache{}
+}
+
+fn (q QueryCache) prepare(tokens []Token) (string, map[string]Value, []Token) {
+	// It's only worth caching specific types of queries.
+	match tokens[0].value {
+		'SELECT', 'INSERT', 'UPDATE', 'DELETE' { return q.prepare_stmt(tokens) }
+		else { return '', map[string]Value{}, tokens }
+	}
+}
+
+fn (q QueryCache) prepare_stmt(tokens []Token) (string, map[string]Value, []Token) {
+	mut key := ''
+	mut i := 0
+	mut params := map[string]Value{}
+
+	// TODO(elliotchance): It's not efficient to expand the number of tokens
+	//  like this. Perhaps the parser should just understand a new type of
+	//  placeholder so it can be replaced in place?
+	mut new_tokens := []Token{cap: tokens.len}
+
+	for j, token in tokens {
+		mut ignore := false
+
+		// Do not replace with placeholders for parts of a number.
+		//
+		// TODO(elliotchance): This should actually replace the exact decimal
+		//  number with a placeholder instead of ignoring.
+		if j < tokens.len - 1 && tokens[j + 1].kind == .period {
+			ignore = true
+		}
+		if j > 0 && tokens[j - 1].kind == .period {
+			ignore = true
+		}
+
+		if !ignore {
+			match token.kind {
+				.literal_number {
+					key += ':p$i '
+					if token.value.f64() == token.value.int() {
+						params['p$i'] = new_integer_value(token.value.int())
+					} else {
+						params['p$i'] = new_double_precision_value(token.value.f64())
+					}
+					new_tokens << Token{.colon, ':'}
+					new_tokens << Token{.literal_identifier, 'p$i'}
+					i++
+					continue
+				}
+				.literal_string {
+					key += ':p$i '
+					params['p$i'] = new_varchar_value(token.value, 0)
+					new_tokens << Token{.colon, ':'}
+					new_tokens << Token{.literal_identifier, 'p$i'}
+					i++
+					continue
+				}
+				else {}
+			}
+		}
+
+		key += token.value.to_upper() + ' '
+		new_tokens << token
+	}
+
+	return key, params, new_tokens
+}
+
+fn (mut q QueryCache) parse(query string) ?(Stmt, map[string]Value) {
+	mut tokens := tokenize(query)
+	key, params, new_tokens := q.prepare(tokens)
+	if key == '' {
+		stmt := parse(new_tokens) ?
+		return stmt, map[string]Value{}
+	}
+
+	if key !in q.stmts {
+		q.stmts[key] = parse(new_tokens) ?
+	}
+
+	return q.stmts[key], params
+}

--- a/vsql/server.v
+++ b/vsql/server.v
@@ -18,7 +18,9 @@ pub struct ServerOptions {
 }
 
 pub fn new_server(options ServerOptions) Server {
-	return Server{options, Connection{}}
+	return Server{options, Connection{
+		query_cache: new_query_cache()
+	}}
 }
 
 pub fn (mut s Server) start() ? {

--- a/vsql/sql_test.v
+++ b/vsql/sql_test.v
@@ -77,13 +77,16 @@ fn get_tests() ?[]SQLTest {
 }
 
 fn test_all() ? {
+	query_cache := new_query_cache()
 	for test in get_tests() ? {
 		path := '/tmp/test.vsql'
 		if os.exists(path) {
 			os.rm(path) ?
 		}
 
-		mut db := open(path) ?
+		mut options := default_connection_options()
+		options.query_cache = query_cache
+		mut db := open_database(path, options) ?
 
 		register_pg_functions(mut db) ?
 


### PR DESCRIPTION
The query cache provides tooling to cache previously parsed prepared
statements. This is becuase parsing a statement is extremely expensive
with the current Earley implementation and many queries (excluding
values) are used more than once.

The query cache is made more useful by the fact it can turn any
existing query into a prepared statement so that cache works in all
cases.

A new query cache is provided with a connection. However, you can also
share a query cache between multiple connections. This is done in tests
to both speed up the tests and to battle test the query cache with a
lot of queries over many connections.

Also fixed a bug where host parameters could not be used in FETCH and
OFFSET clauses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/35)
<!-- Reviewable:end -->
