### PR TITLE
Adding "bench" tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ no dependencies.
   - [Keywords](https://github.com/elliotchance/vsql/blob/main/docs/keywords.rst)
   - [Operators](https://github.com/elliotchance/vsql/blob/main/docs/operators.rst)
   - [SQLSTATE (Errors)](https://github.com/elliotchance/vsql/blob/main/docs/sqlstate.rst)
+- [Benchmark](https://github.com/elliotchance/vsql/blob/main/docs/benchmark.rst)
 - [Development](https://github.com/elliotchance/vsql/blob/main/docs/development.rst)
 - [Testing](https://github.com/elliotchance/vsql/blob/main/docs/testing.rst)
 

--- a/cmd/.gitignore
+++ b/cmd/.gitignore
@@ -1,0 +1,2 @@
+vsql
+vsql.dSYM

--- a/cmd/vsql.v
+++ b/cmd/vsql.v
@@ -33,6 +33,13 @@ fn main() {
 	})
 	cmd.add_command(server_cmd)
 
+	mut bench_cmd := cli.Command{
+		name: 'bench'
+		description: 'Run benchmark'
+		execute: bench_command
+	}
+	cmd.add_command(bench_cmd)
+
 	cmd.setup()
 	cmd.parse(os.args)
 }
@@ -66,7 +73,6 @@ fn server_command(cmd cli.Command) {
 		port = 3210
 	}
 
-	// TODO(elliotchance): Make port a CLI option.
 	mut server := vsql.new_server(vsql.ServerOptions{
 		db_file: cmd.args[0]
 		port: port
@@ -74,4 +80,11 @@ fn server_command(cmd cli.Command) {
 	})
 
 	server.start() or { panic(err) }
+}
+
+fn bench_command(cmd cli.Command) {
+	mut conn := vsql.open('bench.vsql') or { panic('$err') }
+
+	mut benchmark := vsql.new_benchmark(conn)
+	benchmark.start() or { panic('$err') }
 }

--- a/docs/benchmark.rst
+++ b/docs/benchmark.rst
@@ -1,0 +1,92 @@
+Benchmark
+=========
+
+The main focus of vsql is on compatibility and features of the SQL standard.
+That does not mean that speed is not important, but less important since there
+are already a wide array of products out there that are battled tested and tuned
+to perfection. This page is useful to compare the relative performance
+improvements between releases.
+
+.. contents::
+
+Process
+-------
+
+With the default (no options) ``vsql bench`` runs a TPC-B-like transactional
+test that is inspired by (copied from)
+`PostgreSQL's pgbench tool <https://www.postgresql.org/docs/10/pgbench.html>`_.
+And executes the following:
+
+1. Create an ``ACCOUNTS`` table with 100,000 rows.
+2. Create a ``TELLER`` table with 10 rows.
+3. Create a ``BRANCH`` table with a single row.
+4. Create a ``HISTORY`` table that is empty.
+5. Will run as many transactions as it can within 60 seconds.
+
+A transaction consists of 5 statements (in order):
+
+1. ``UPDATE accounts SET abalance = abalance + :delta WHERE aid = :aid``
+2. ``SELECT abalance FROM accounts WHERE aid = :aid``
+3. ``UPDATE tellers SET tbalance = tbalance + $delta WHERE tid = :tid``
+4. ``UPDATE branches SET bbalance = bbalance + $delta WHERE bid = :bid``
+5. ``INSERT INTO history (tid, bid, aid, delta, mtime) VALUES (:tid, :bid, :aid, :delta, CURRENT_TIMESTAMP)``
+
+Where ``:aid``, ``:tid`` and ``:bid`` are random integers that are within the
+their respective ranges and ``:delta`` is a random value between -5000 and 5000.
+
+After the benchmark is finished it will report something like:
+
+.. code-block:: txt
+
+   INSERT: 100000 rows in 19.692 (5078.086 rows/s)
+   SELECT: 100000 rows in 0.845 (118389.150 rows/s)
+   TCP-B (sort of): 25 transactions in 61.963 (0.403 transactions/s)
+
+Where:
+
+- ``INSERT`` describes the raw INSERT rate into the largest table ``ACCOUNTS``.
+- ``SELECT`` describes the raw SELECT read rate with a simple filter (``aid = 0``). This will not match any records but it will ensure the entire table is read.
+- ``TCP-B (sort of)`` is the result from the test explained above.
+
+Notes
+-----
+
+1. It may look initially suspicious that the ``INSERT`` and ``SELECT`` speeds
+seem reasonable but ``TCP-B (sort of)`` is extremely slow. This is because vsql
+does not have any indexes yet, so each transaction is effectievly reading all
+rows 4 times. This will be substantially improved in the future.
+
+2. ``CURRENT_TIMESTAMP`` is not yet supported, so a V generated timestamp as
+``VARCHAR`` is used instead.
+
+3. ``INSERT`` only inserts one row per statement (rather than bulk inserts with
+a single statement). Bulk inserts are not yet supported, although when they are
+this mechanic will probably not change.
+
+4. The ``bench`` command will create a file called ``bench.vsql`` for the test.
+If the file already exists the command will fail as it tries to create tables
+that already exist. You must delete ``bench.vsql`` between test runs.
+
+Results
+-------
+
+These were run on:
+
+- MacBook Pro (Retina, 15-inch, Late 2013)
+- 2.3 GHz Quad-Core Intel Core i7
+- 16 GB 1600 MHz DDR3
+
+.. list-table::
+  :header-rows: 1
+
+  * - Date
+    - Version
+    - INSERT (rows/s)
+    - SELECT (rows/s)
+    - TCP-B (tps)
+
+  * - 2021-09-04
+    - `v0.11.0 <https://github.com/elliotchance/vsql/releases/tag/v0.11.0>`_
+    - 5107
+    - 129252
+    - 0.378

--- a/vsql/bench.v
+++ b/vsql/bench.v
@@ -1,0 +1,99 @@
+// bench.v contains functionality to benchmark the performance of vsql. This is
+// useful as a local tool and provides insights into changes for performance
+// between vsql versions. The test itself is inspired/copied from pgbench.
+//
+// Usage:
+//
+//   vsql bench
+//
+// See https://github.com/elliotchance/vsql/blob/main/docs/benchmark.rst
+
+module vsql
+
+import rand
+import time
+
+pub struct Benchmark {
+pub mut:
+	conn         Connection
+	account_rows int
+	teller_rows  int
+	branch_rows  int
+	run_for      time.Duration
+}
+
+pub fn new_benchmark(conn Connection) Benchmark {
+	return Benchmark{
+		account_rows: 100000
+		teller_rows: 10
+		branch_rows: 1
+		run_for: time.minute
+		conn: conn
+	}
+}
+
+pub fn (mut b Benchmark) start() ? {
+	b.conn.query('CREATE TABLE accounts ( aid INT, abalance INT ) ') ?
+
+	mut t := start_timer()
+	for aid in 1 .. b.account_rows + 1 {
+		b.conn.query('INSERT INTO accounts (aid, abalance) VALUES ($aid, 0)') ?
+	}
+	b.print_stat('INSERT', b.account_rows, 'rows', t.elapsed())
+
+	b.conn.query('CREATE TABLE tellers ( tid INT, tbalance INT ) ') ?
+	for tid in 1 .. b.teller_rows + 1 {
+		b.conn.query('INSERT INTO tellers (tid, tbalance) VALUES ($tid, 0)') ?
+	}
+
+	b.conn.query('CREATE TABLE branches ( bid INT, bbalance INT ) ') ?
+	for bid in 1 .. b.branch_rows + 1 {
+		b.conn.query('INSERT INTO branches (bid, bbalance) VALUES ($bid, 0)') ?
+	}
+
+	b.conn.query('CREATE TABLE history ( tid INT, bid INT, aid INT, delta INT, mtime VARCHAR(30) ) ') ?
+
+	t = start_timer()
+	b.conn.query('SELECT abalance FROM accounts WHERE aid = 0') ?
+	b.print_stat('SELECT', b.account_rows, 'rows', t.elapsed())
+
+	t = start_timer()
+	mut txn_count := 0
+	for {
+		b.run_transaction() ?
+		txn_count++
+
+		if t.elapsed() > b.run_for {
+			break
+		}
+	}
+
+	b.print_stat('TCP-B (sort of)', txn_count, 'transactions', t.elapsed())
+}
+
+fn (mut b Benchmark) print_stat(name string, n int, unit string, elapsed time.Duration) {
+	println('$name: $n $unit in ${elapsed.seconds():.3f} (${n / elapsed.seconds():.3f} $unit/s)')
+}
+
+fn (mut b Benchmark) run_transaction() ? {
+	aid := b.random(1, b.account_rows)
+	bid := b.random(1, b.branch_rows)
+	tid := b.random(1, b.teller_rows)
+	delta := b.random(-5000, 5000)
+
+	b.conn.query('UPDATE accounts SET abalance = abalance + $delta WHERE aid = $aid') ?
+	b.conn.query('SELECT abalance FROM accounts WHERE aid = $aid') ?
+	b.conn.query('UPDATE tellers SET tbalance = tbalance + $delta WHERE tid = $tid') ?
+	b.conn.query('UPDATE branches SET bbalance = bbalance + $delta WHERE bid = $bid') ?
+
+	// TODO(elliotchance): Should use CURRENT_TIMESTAMP once supported.
+	b.conn.query('INSERT INTO history (tid, bid, aid, delta, mtime) VALUES ($tid, $bid, $aid, $delta, \'$time.now()\')') ?
+}
+
+fn (b Benchmark) random(min int, max int) int {
+	if min == max {
+		return min
+	}
+
+	return (rand.int31() % (max - min)) + min
+}

--- a/vsql/connection.v
+++ b/vsql/connection.v
@@ -4,7 +4,7 @@
 module vsql
 
 [heap]
-struct Connection {
+pub struct Connection {
 mut:
 	storage        FileStorage
 	funcs          map[string]Func
@@ -27,10 +27,11 @@ pub fn open_database(path string, options ConnectionOptions) ?Connection {
 }
 
 pub fn (mut c Connection) prepare(sql string) ?PreparedStmt {
+	t := start_timer()
 	stmt, params := c.query_cache.parse(sql) ?
-	println('> $stmt $params')
+	elapsed_parse := t.elapsed()
 
-	return PreparedStmt{stmt, params, &c}
+	return PreparedStmt{stmt, params, &c, elapsed_parse}
 }
 
 pub fn (mut c Connection) query(sql string) ?Result {

--- a/vsql/create_table.v
+++ b/vsql/create_table.v
@@ -2,9 +2,12 @@
 
 module vsql
 
+import time
+
 // TODO(elliotchance): A table is allowed to have zero columns.
 
-fn execute_create_table(mut c Connection, stmt CreateTableStmt) ?Result {
+fn execute_create_table(mut c Connection, stmt CreateTableStmt, elapsed_parse time.Duration) ?Result {
+	t := start_timer()
 	table_name := identifier_name(stmt.table_name)
 
 	if table_name in c.storage.tables {
@@ -20,5 +23,5 @@ fn execute_create_table(mut c Connection, stmt CreateTableStmt) ?Result {
 
 	c.storage.create_table(table_name, columns) ?
 
-	return new_result_msg('CREATE TABLE 1')
+	return new_result_msg('CREATE TABLE 1', elapsed_parse, t.elapsed())
 }

--- a/vsql/delete.v
+++ b/vsql/delete.v
@@ -2,7 +2,10 @@
 
 module vsql
 
-fn execute_delete(mut c Connection, stmt DeleteStmt, params map[string]Value) ?Result {
+import time
+
+fn execute_delete(mut c Connection, stmt DeleteStmt, params map[string]Value, elapsed_parse time.Duration) ?Result {
+	t := start_timer()
 	table_name := identifier_name(stmt.table_name)
 
 	if table_name !in c.storage.tables {
@@ -25,5 +28,5 @@ fn execute_delete(mut c Connection, stmt DeleteStmt, params map[string]Value) ?R
 		}
 	}
 
-	return new_result_msg('DELETE $deleted')
+	return new_result_msg('DELETE $deleted', elapsed_parse, t.elapsed())
 }

--- a/vsql/drop_table.v
+++ b/vsql/drop_table.v
@@ -2,7 +2,10 @@
 
 module vsql
 
-fn execute_drop_table(mut c Connection, stmt DropTableStmt) ?Result {
+import time
+
+fn execute_drop_table(mut c Connection, stmt DropTableStmt, elapsed_parse time.Duration) ?Result {
+	t := start_timer()
 	table_name := identifier_name(stmt.table_name)
 
 	if table_name !in c.storage.tables {
@@ -12,5 +15,5 @@ fn execute_drop_table(mut c Connection, stmt DropTableStmt) ?Result {
 	// TODO(elliotchance): Also delete rows.
 	c.storage.delete_table(table_name) ?
 
-	return new_result_msg('DROP TABLE 1')
+	return new_result_msg('DROP TABLE 1', elapsed_parse, t.elapsed())
 }

--- a/vsql/insert.v
+++ b/vsql/insert.v
@@ -2,7 +2,11 @@
 
 module vsql
 
-fn execute_insert(mut c Connection, stmt InsertStmt, params map[string]Value) ?Result {
+import time
+
+fn execute_insert(mut c Connection, stmt InsertStmt, params map[string]Value, elapsed_parse time.Duration) ?Result {
+	t := start_timer()
+
 	mut row := Row{
 		data: map[string]Value{}
 	}
@@ -49,5 +53,5 @@ fn execute_insert(mut c Connection, stmt InsertStmt, params map[string]Value) ?R
 
 	c.storage.write_row(row, table) ?
 
-	return new_result_msg('INSERT 1')
+	return new_result_msg('INSERT 1', elapsed_parse, t.elapsed())
 }

--- a/vsql/prepare.v
+++ b/vsql/prepare.v
@@ -5,6 +5,8 @@
 
 module vsql
 
+import time
+
 struct PreparedStmt {
 	stmt Stmt
 	// params can be set on the statement and will be merged with the extra
@@ -12,12 +14,11 @@ struct PreparedStmt {
 	// at execution time will take precedence.
 	params map[string]Value
 mut:
-	c &Connection
+	c             &Connection
+	elapsed_parse time.Duration
 }
 
 pub fn (mut p PreparedStmt) query(params map[string]Value) ?Result {
-	stmt := p.stmt
-
 	mut all_params := params.clone()
 	for k, v in p.params {
 		if k !in all_params {
@@ -25,24 +26,25 @@ pub fn (mut p PreparedStmt) query(params map[string]Value) ?Result {
 		}
 	}
 
+	stmt := p.stmt
 	match stmt {
 		CreateTableStmt {
-			return execute_create_table(mut p.c, stmt)
+			return execute_create_table(mut p.c, stmt, p.elapsed_parse)
 		}
 		DeleteStmt {
-			return execute_delete(mut p.c, stmt, all_params)
+			return execute_delete(mut p.c, stmt, all_params, p.elapsed_parse)
 		}
 		DropTableStmt {
-			return execute_drop_table(mut p.c, stmt)
+			return execute_drop_table(mut p.c, stmt, p.elapsed_parse)
 		}
 		InsertStmt {
-			return execute_insert(mut p.c, stmt, all_params)
+			return execute_insert(mut p.c, stmt, all_params, p.elapsed_parse)
 		}
 		SelectStmt {
-			return execute_select(mut p.c, stmt, all_params)
+			return execute_select(mut p.c, stmt, all_params, p.elapsed_parse)
 		}
 		UpdateStmt {
-			return execute_update(mut p.c, stmt, all_params)
+			return execute_update(mut p.c, stmt, all_params, p.elapsed_parse)
 		}
 	}
 }

--- a/vsql/result.v
+++ b/vsql/result.v
@@ -3,29 +3,35 @@
 
 module vsql
 
+import time
+
 struct Result {
 pub:
-	columns []string
-	rows    []Row
+	columns       []string
+	rows          []Row
+	elapsed_parse time.Duration
+	elapsed_exec  time.Duration
 mut:
 	idx int
 }
 
-pub fn new_result(columns []string, rows []Row) Result {
+pub fn new_result(columns []string, rows []Row, elapsed_parse time.Duration, elapsed_exec time.Duration) Result {
 	return Result{
 		columns: columns
 		rows: rows
+		elapsed_parse: elapsed_parse
+		elapsed_exec: elapsed_exec
 	}
 }
 
-fn new_result_msg(msg string) Result {
+fn new_result_msg(msg string, elapsed_parse time.Duration, elapsed_exec time.Duration) Result {
 	return new_result(['msg'], [
 		Row{
 			data: {
 				'msg': new_varchar_value(msg, 0)
 			}
 		},
-	])
+	], elapsed_parse, elapsed_exec)
 }
 
 pub fn (mut r Result) next() ?Row {

--- a/vsql/server.v
+++ b/vsql/server.v
@@ -99,7 +99,7 @@ fn (mut s Server) handle_conn(mut c net.TcpConn) ? {
 					s.log('error: $err')
 
 					conn.write_error_result(err) ?
-					new_result([]string{}, []Row{}) // not used
+					new_result([]string{}, []Row{}, 0, 0) // not used
 				}
 
 				if !did_error {

--- a/vsql/timer.v
+++ b/vsql/timer.v
@@ -1,0 +1,19 @@
+// timer.v is used to record durations of actions.
+
+module vsql
+
+import time
+
+struct Timer {
+	started_at time.Time
+}
+
+fn start_timer() Timer {
+	return Timer{
+		started_at: time.now()
+	}
+}
+
+fn (t Timer) elapsed() time.Duration {
+	return time.now() - t.started_at
+}

--- a/vsql/update.v
+++ b/vsql/update.v
@@ -2,7 +2,11 @@
 
 module vsql
 
-fn execute_update(mut c Connection, stmt UpdateStmt, params map[string]Value) ?Result {
+import time
+
+fn execute_update(mut c Connection, stmt UpdateStmt, params map[string]Value, elapsed_parse time.Duration) ?Result {
+	t := start_timer()
+
 	table_name := identifier_name(stmt.table_name)
 
 	if table_name !in c.storage.tables {
@@ -68,5 +72,5 @@ fn execute_update(mut c Connection, stmt UpdateStmt, params map[string]Value) ?R
 		c.storage.write_row(row, table) ?
 	}
 
-	return new_result_msg('UPDATE $new_rows.len')
+	return new_result_msg('UPDATE $new_rows.len', elapsed_parse, t.elapsed())
 }


### PR DESCRIPTION
A new command "vsql bench" can now be used to benchmark the performance
of vsql. This is useful as a local tool and provides insides to changes
in performance between vsql versions. The TPC-B-like commands are
inspired/copied from pgbench.

See https://github.com/elliotchance/vsql/blob/main/docs/benchmark.rst

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/36)
<!-- Reviewable:end -->
