### PR TITLE
Changing storage format

### DIFF
--- a/vsql/ast.v
+++ b/vsql/ast.v
@@ -6,8 +6,15 @@ module vsql
 type Stmt = CreateTableStmt | DeleteStmt | DropTableStmt | InsertStmt | SelectStmt | UpdateStmt
 
 // All possible expression entities.
-type Expr = BinaryExpr | CallExpr | Identifier | NamedExpr | NoExpr | NullExpr | Parameter |
-	UnaryExpr | Value
+type Expr = BinaryExpr
+	| CallExpr
+	| Identifier
+	| NamedExpr
+	| NoExpr
+	| NullExpr
+	| Parameter
+	| UnaryExpr
+	| Value
 
 // CREATE TABLE ...
 struct CreateTableStmt {

--- a/vsql/bytes.v
+++ b/vsql/bytes.v
@@ -1,0 +1,174 @@
+// bytes.v contains a byte stream that can be read from and written to.
+
+module vsql
+
+struct Bytes {
+mut:
+	at   int
+	data []byte
+}
+
+fn new_bytes(data []byte) Bytes {
+	return Bytes{
+		data: data.clone()
+	}
+}
+
+fn (mut b Bytes) write_bool(d bool) {
+	b.write_byte(if d { byte(1) } else { 0 })
+}
+
+fn (mut b Bytes) read_bool() bool {
+	return b.read_byte() != 0
+}
+
+fn (mut b Bytes) write_byte(d byte) {
+	b.data << d
+}
+
+fn (mut b Bytes) read_byte() byte {
+	b.at++
+	return b.data[b.at - 1]
+}
+
+fn (mut b Bytes) write_bytes(data []byte) {
+	for d in data {
+		b.data << d
+	}
+}
+
+fn (mut b Bytes) read_bytes(len int) []byte {
+	data := b.data[b.at..b.at + len]
+	b.at += len
+	return data
+}
+
+fn (mut b Bytes) write_string1(s string) {
+	b.write_byte(byte(s.len))
+	b.write_bytes(s.bytes())
+}
+
+fn (mut b Bytes) read_string(len int) string {
+	return b.read_bytes(len).bytestr()
+}
+
+fn (mut b Bytes) read_string1() string {
+	len := b.read_byte()
+	return b.read_string(len)
+}
+
+fn (mut b Bytes) write_string4(s string) {
+	b.write_int(s.len)
+	b.write_bytes(s.bytes())
+}
+
+fn (mut b Bytes) read_string4() string {
+	len := b.read_int()
+	return b.read_string(len)
+}
+
+union Bytes2 {
+	bytes     [2]byte
+	i16_value i16
+}
+
+fn (b Bytes2) bytes() []byte {
+	return unsafe { [b.bytes[0], b.bytes[1]] }
+}
+
+fn (mut b Bytes) write_i16(d i16) {
+	b.write_bytes(Bytes2{ i16_value: d }.bytes())
+}
+
+fn (mut b Bytes) write_int(x int) {
+	b.write_bytes(Bytes4{ int_value: x }.bytes())
+}
+
+fn (mut b Bytes) read_i16() i16 {
+	bytes := b.read_bytes(2)
+	return unsafe {
+		Bytes2{
+			bytes: [bytes[0], bytes[1]]!
+		}.i16_value
+	}
+}
+
+fn (mut b Bytes) read_int() int {
+	bytes := b.read_bytes(4)
+	return unsafe {
+		Bytes4{
+			bytes: [bytes[0], bytes[1], bytes[2], bytes[3]]!
+		}.int_value
+	}
+}
+
+fn (b Bytes) bytes() []byte {
+	return b.data.clone()
+}
+
+fn (b Bytes) has_more() bool {
+	return b.at < b.data.len
+}
+
+union Bytes8 {
+	bytes     [8]byte
+	f64_value f64
+	i64_value i64
+}
+
+fn (b Bytes8) bytes() []byte {
+	return unsafe {
+		[b.bytes[0], b.bytes[1], b.bytes[2], b.bytes[3], b.bytes[4], b.bytes[5], b.bytes[6],
+			b.bytes[7],
+		]
+	}
+}
+
+fn (mut b Bytes) write_f64(x f64) {
+	b.write_bytes(Bytes8{ f64_value: x }.bytes())
+}
+
+fn (mut b Bytes) write_i64(x i64) {
+	b.write_bytes(Bytes8{ i64_value: x }.bytes())
+}
+
+union Bytes4 {
+	bytes     [4]byte
+	f32_value f32
+	int_value int
+}
+
+fn (b Bytes4) bytes() []byte {
+	return unsafe { [b.bytes[0], b.bytes[1], b.bytes[2], b.bytes[3]] }
+}
+
+fn (mut b Bytes) write_f32(x f32) {
+	b.write_bytes(Bytes4{ f32_value: x }.bytes())
+}
+
+fn (mut b Bytes) read_f32() f32 {
+	bytes := b.read_bytes(4)
+	return unsafe {
+		Bytes4{
+			bytes: [bytes[0], bytes[1], bytes[2], bytes[3]]!
+		}.f32_value
+	}
+}
+
+fn (mut b Bytes) read_f64() f64 {
+	bytes := b.read_bytes(8)
+	return unsafe {
+		Bytes8{
+			bytes: [bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]]!
+		}.f64_value
+	}
+}
+
+fn (mut b Bytes) read_i64() i64 {
+	bytes := b.read_bytes(8)
+	return unsafe {
+		Bytes8{
+			bytes: [bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]]!
+		}.i64_value
+	}
+}

--- a/vsql/cast.v
+++ b/vsql/cast.v
@@ -13,49 +13,89 @@ fn cast(msg string, v Value, to Type) ?Value {
 		}
 		.is_boolean {
 			match to.typ {
-				.is_boolean { return v }
+				.is_boolean {
+					return Value{
+						typ: to
+						f64_value: v.f64_value
+					}
+				}
 				else {}
 			}
 		}
 		.is_bigint {
 			match to.typ {
-				.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint { return v }
+				.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint {
+					return Value{
+						typ: to
+						f64_value: v.f64_value
+					}
+				}
 				else {}
 			}
 		}
 		.is_character {
 			match to.typ {
-				.is_character, .is_varchar { return v }
+				.is_character, .is_varchar {
+					return Value{
+						typ: to
+						string_value: v.string_value
+					}
+				}
 				else {}
 			}
 		}
 		.is_double_precision {
 			match to.typ {
-				.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint { return v }
+				.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint {
+					return Value{
+						typ: to
+						f64_value: v.f64_value
+					}
+				}
 				else {}
 			}
 		}
 		.is_integer {
 			match to.typ {
-				.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint { return v }
+				.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint {
+					return Value{
+						typ: to
+						f64_value: v.f64_value
+					}
+				}
 				else {}
 			}
 		}
 		.is_real {
 			match to.typ {
-				.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint { return v }
+				.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint {
+					return Value{
+						typ: to
+						f64_value: v.f64_value
+					}
+				}
 				else {}
 			}
 		}
 		.is_smallint {
 			match to.typ {
-				.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint { return v }
+				.is_bigint, .is_double_precision, .is_integer, .is_real, .is_smallint {
+					return Value{
+						typ: to
+						f64_value: v.f64_value
+					}
+				}
 				else {}
 			}
 		}
 		.is_varchar {
 			match to.typ {
-				.is_varchar, .is_character { return v }
+				.is_varchar, .is_character {
+					return Value{
+						typ: to
+						string_value: v.string_value
+					}
+				}
 				else {}
 			}
 		}

--- a/vsql/earley.v
+++ b/vsql/earley.v
@@ -299,7 +299,7 @@ fn build_trees_helper(children []EarleyNode, state EarleyState, rule_index int, 
 	if rule_index < 0 {
 		return [EarleyNode{state, children}]
 	} else if rule_index == 0 {
-		start_column = state.start_column
+		start_column = *state.start_column
 	}
 
 	rule := state.rules[rule_index]

--- a/vsql/grammar.v
+++ b/vsql/grammar.v
@@ -4,9 +4,25 @@
 
 module vsql
 
-type EarleyValue = Column | ComparisonPredicatePart2 | CreateTableStmt | DerivedColumn |
-	Expr | Identifier | InsertStmt | SelectList | SelectStmt | Stmt | TableExpression |
-	Type | Value | []Column | []Expr | []Identifier | bool | map[string]Expr | string
+type EarleyValue = Column
+	| ComparisonPredicatePart2
+	| CreateTableStmt
+	| DerivedColumn
+	| Expr
+	| Identifier
+	| InsertStmt
+	| SelectList
+	| SelectStmt
+	| Stmt
+	| TableExpression
+	| Type
+	| Value
+	| []Column
+	| []Expr
+	| []Identifier
+	| bool
+	| map[string]Expr
+	| string
 
 fn get_grammar() map[string]EarleyRule {
 	mut rules := map[string]EarleyRule{}

--- a/vsql/query_cache.v
+++ b/vsql/query_cache.v
@@ -94,5 +94,5 @@ fn (mut q QueryCache) parse(query string) ?(Stmt, map[string]Value) {
 		q.stmts[key] = parse(new_tokens) ?
 	}
 
-	return q.stmts[key], params
+	return q.stmts[key] or { panic('impossible') }, params
 }

--- a/vsql/table.v
+++ b/vsql/table.v
@@ -34,3 +34,40 @@ fn (t Table) column(name string) ?Column {
 
 	return sqlstate_42703(name) // column does not exist
 }
+
+fn (t Table) bytes() []byte {
+	mut b := new_bytes([]byte{})
+
+	b.write_int(t.index)
+	b.write_string1(t.name)
+
+	for col in t.columns {
+		b.write_string1(col.name)
+		b.write_byte(col.typ.number())
+		b.write_bool(col.not_null)
+		b.write_i16(0) // size
+		b.write_i16(0) // precision
+	}
+
+	return b.bytes()
+}
+
+fn new_table_from_bytes(data []byte, offset u32) Table {
+	mut b := new_bytes(data)
+
+	index := b.read_int()
+	table_name := b.read_string1()
+
+	mut columns := []Column{}
+	for b.has_more() {
+		column_name := b.read_string1()
+		column_type := b.read_byte()
+		is_not_null := b.read_bool()
+		b.read_i16() // size
+		b.read_i16() // precision
+
+		columns << Column{column_name, type_from_number(column_type), is_not_null}
+	}
+
+	return Table{offset, index, table_name, columns}
+}

--- a/vsql/type.v
+++ b/vsql/type.v
@@ -3,6 +3,8 @@
 module vsql
 
 struct Type {
+mut:
+	// TODO(elliotchance): Make these non-mutable.
 	typ  SQLType
 	size int // the size/precision specified for the type
 }
@@ -89,4 +91,33 @@ fn (t Type) uses_string() bool {
 			true
 		}
 	}
+}
+
+fn (t Type) number() byte {
+	return match t.typ {
+		.is_null { 0 }
+		.is_boolean { 1 }
+		.is_bigint { 2 }
+		.is_double_precision { 3 }
+		.is_integer { 4 }
+		.is_real { 5 }
+		.is_smallint { 6 }
+		.is_varchar { 7 }
+		.is_character { 8 }
+	}
+}
+
+fn type_from_number(number byte) Type {
+	return new_type(match number {
+		0 { 'NULL' }
+		1 { 'BOOLEAN' }
+		2 { 'BIGINT' }
+		3 { 'DOUBLE PRECISION' }
+		4 { 'INTEGER' }
+		5 { 'REAL' }
+		6 { 'SMALLINT' }
+		7 { 'CHARACTER VARYING' }
+		8 { 'CHARACTER' }
+		else { panic(number) }
+	}, 0)
 }

--- a/vsql/value.v
+++ b/vsql/value.v
@@ -5,7 +5,8 @@
 module vsql
 
 pub struct Value {
-pub:
+pub mut:
+	// TODO(elliotchance): Make these non-mutable.
 	typ          Type
 	f64_value    f64    // boolean and numeric
 	string_value string // char and varchar
@@ -53,15 +54,30 @@ pub fn new_varchar_value(x string, size int) Value {
 }
 
 pub fn (v Value) == (v2 Value) bool {
-	return match v.typ.typ {
+	match v.typ.typ {
 		.is_null {
-			false
+			return false
 		}
+		// TODO(elliotchance): BOOLEAN shouldn't be compared this way.
 		.is_boolean, .is_bigint, .is_integer, .is_smallint, .is_double_precision, .is_real {
-			v2.typ.typ == v.typ.typ && v.f64_value == v2.f64_value
+			return match v2.typ.typ {
+				.is_boolean, .is_bigint, .is_integer, .is_smallint, .is_double_precision, .is_real {
+					v.f64_value == v2.f64_value
+				}
+				else {
+					false
+				}
+			}
 		}
 		.is_varchar, .is_character {
-			v2.typ.typ == v.typ.typ && v.string_value == v2.string_value
+			return match v2.typ.typ {
+				.is_varchar, .is_character {
+					v.string_value == v2.string_value
+				}
+				else {
+					false
+				}
+			}
 		}
 	}
 }
@@ -70,7 +86,8 @@ fn bool_str(x f64) string {
 	return match x {
 		0 { 'FALSE' }
 		1 { 'TRUE' }
-		else { 'UNKNOWN' }
+		2 { 'UNKNOWN' }
+		else { 'NULL' }
 	}
 }
 


### PR DESCRIPTION
This is a radical change to the storage format that converts each object
(row or table) to being encoded and decoded by the entity itself rather
than the storage itself. This change is required in preparation for the
next major release that will use a B-tree on disk rather than the list
of objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/40)
<!-- Reviewable:end -->
