### PR TITLE
Rewrite file format to be a B-tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
       run: v fmt -verify .
 
     - name: Run SQL tests
-      run: v -stats -prod test vsql
+      run: v -stats -gc boehm -prod test vsql
 
     - name: Run examples
-      run: for f in `ls examples/*.v`; do v -prod run $f; done
+      run: for f in `ls examples/*.v`; do v -gc boehm -prod run $f; done
 
     - name: Set version
       if: startsWith(github.ref, 'refs/tags/')
@@ -35,7 +35,7 @@ jobs:
 
     - name: Build macOS binaries
       run: |
-        v -prod cmd/vsql.v
+        v -gc boehm -prod cmd/vsql.v
         zip -j vsql-macos.zip cmd/vsql
 
     # See https://github.com/vlang/v/issues/10992
@@ -50,7 +50,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       run: |
         brew install mingw-w64
-        v -os windows -prod cmd/vsql.v
+        v -os windows -gc boehm -prod cmd/vsql.v
         zip -j vsql-windows.zip cmd/vsql.exe
 
     - name: Release

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ no dependencies.
   - [UPDATE](https://github.com/elliotchance/vsql/blob/main/docs/update.rst)
 - [Appendix](#appendix)
   - [Data Types](https://github.com/elliotchance/vsql/blob/main/docs/data-types.rst)
+  - [File Format](https://github.com/elliotchance/vsql/blob/main/docs/file-format.rst)
   - [Functions](https://github.com/elliotchance/vsql/blob/main/docs/functions.rst)
   - [Keywords](https://github.com/elliotchance/vsql/blob/main/docs/keywords.rst)
   - [Operators](https://github.com/elliotchance/vsql/blob/main/docs/operators.rst)

--- a/docs/benchmark.rst
+++ b/docs/benchmark.rst
@@ -84,9 +84,18 @@ These were run on:
     - INSERT (rows/s)
     - SELECT (rows/s)
     - TCP-B (tps)
+    - Notes
 
   * - 2021-09-04
     - `v0.11.0 <https://github.com/elliotchance/vsql/releases/tag/v0.11.0>`_
     - 5107
     - 129252
     - 0.378
+    - This first version of the storage format is basically a binary CSV. Where tables and rows are treated as objects in a stream. That is, to find a record is to read (and decode) all rows from every table.
+
+  * - 2021-09-15
+    - `v0.12.0 <https://github.com/elliotchance/vsql/releases/tag/v0.12.0>`_
+    - 355
+    - 71851
+    - 0.377
+    - This version completely replaces the storage engine with with a B-tree on disk. Although the ``INSERT`` and ``SELECT`` speeds are much lower, the same transaction throughput is retained because it no longer has to scan the full file for any ``SELECT`` operation. The current implementation uses a 4kb page, but leaves a lot of low hanging fruit for optimization, however, this version only focused on functionalty and not performance.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -5,6 +5,25 @@ This page is aimed to developers of vsql.
 
 .. contents::
 
+Building from Source
+--------------------
+
+Building the binary from source is pretty straight forward. However, you should
+be aware that the current default garbage collection mechanism (``-autofree``)
+is not yet stable enough and stress testing vsql will lead to memory leaks.
+
+For the timebeing, you must use the ``boehm`` garbage collection mode:
+
+.. code-block:: sh
+
+  v -gc boehm -prod cmd/vsql.v
+
+If you receive an error, you may need to install it on macOS:
+
+.. code-block:: sh
+
+  brew install libgc
+
 Parser & SQL Grammar
 --------------------
 

--- a/docs/file-format.rst
+++ b/docs/file-format.rst
@@ -1,0 +1,332 @@
+File Format
+===========
+
+vsql stores all data in a single file, usually with a ``.vsql`` extension
+(although, that is not required).
+
+The database file consists of a header followed by zero or more pages. All pages
+are the same size and the file will expand in whole pages as more storage is
+needed.
+
+.. contents::
+
+Header
+------
+
+The header is always one page or 4kb (4096 bytes). At the moment only the first
+byte is used for a rudimentary version. It will be expanded out in the future to
+contain a magic number and other metadata for the file.
+
+See https://github.com/elliotchance/vsql/issues/42.
+
+Pages
+-----
+
+Pages are fixed width and may be layed out in any order since they represent a
+single B-tree that contains all records, tables, etc (these are called Objects,
+described below) for the database.
+
+A file will start with zero pages (this does not include the header) since there
+is nothing stored and expand as the B-tree expands as needed.
+
+All pages within a file are the same size (4kb) and each page reserves 3 bytes
+for metadata. The metadata describes the type of page (leaf or non-leaf) and the
+current usage. Objects within a page are kept sorted by key and unused space is
+always after the used data.
+
+A page that contains 2 objects will look like:
+
+.. list-table::
+  :header-rows: 1
+
+  * - Byte Offset
+    - Length
+    - Description
+
+  * - 0
+    - 1 (byte)
+    - Kind (0 = leaf, 1 = non-leaf)
+
+  * - 1
+    - 2 (u16)
+    - Usage of page (including header). The value in this case will be 63. An empty page will have used bytes of 3.
+
+  * - 3
+    - 23 ([]byte)
+    - An object of 23 bytes.
+
+  * - 26
+    - 37 ([]byte)
+    - An object of 37 bytes.
+
+Objects
+-------
+
+Pages are made up of objects. Objects wrap different types of entities (such as
+a table or row) so that page does not need to be dedicated to a particular
+object type.
+
+The key uses a single character prefix to designate what type of object it is.
+For example, ``T`` for tables. See the specific obejct definitions for more
+information.
+
+An object is serialized as:
+
+- 4 bytes (signed integer) for the total length of the object (including self). 4 bytes may seem excessive since the page cannot hold that much, but this is to prepare for a future when a single record spans multiple pages. See https://github.com/elliotchance/vsql/issues/43.
+- 2 bytes (signed integer) for the key length.
+- *n* bytes for the key
+- *n* bytes for the value. The length of the value can be calculated from the total length - 2 - key length.
+
+Here is an example of a *Row Object* (83 bytes) stored as an *Object* (94
+bytes):
+
+.. list-table::
+  :header-rows: 1
+
+  * - Byte Offset
+    - Length
+    - Description
+
+  * - 0
+    - 4 (signed 32-bit int)
+    - 94
+
+  * - 4
+    - 2 (signed 32-bit int)
+    - 5
+
+  * - 6
+    - 5
+    - R12345 (not the true representation, see *Row Objects*)
+
+  * - 11
+    - 83
+    - The *Row Objects* data.
+
+Table Objects
+-------------
+
+The object key for a table is ``T`` followed by the table name, for example
+``TFOO`` for the ``foo`` table (notice the uppercase is because of the SQL
+standard). Whereas the table ``"foo"`` would be ``Tfoo``.
+   
+The table definition is stored as:
+
+- 1 byte (signed integer) for the table name length.
+- *n* bytes for the table name.
+- For each column:
+
+  * 1 byte (signed integer) for the column name length.
+  * *n* bytes for the table name.
+  * 1 byte (signed integer) for the column type (see *Type Number* in *Row Objects*)
+  * 1 byte (signed integer) for NULL constraint (1 = NOT NULL, 0 = nullable).
+  * 2 bytes (signed integer) for size (eg. 100 in ``VARCHAR(100)``).
+  * 2 bytes (signed integer) for precision (eg. 6 in ``DECIMAL(10, 6)``).
+
+For example:
+
+.. code-block:: sql
+
+   CREATE TABLE products (
+       product_id INT NOT NULL,
+       product_name VARCHAR(64) NOT NULL,
+       product_desc VARCHAR(1000)
+   );
+
+Is serialized as 41 bytes:
+
+.. list-table::
+  :header-rows: 1
+
+  * - Byte Offset
+    - Length
+    - Description
+
+  * - 0
+    - 4 (signed int)
+    - 1
+
+  * - 4
+    - 8 ([]byte)
+    - ``PRODUCTS``
+
+  * - 12
+    - 1 (signed int)
+    - 10
+
+  * - 13
+    - 10 ([]byte)
+    - ``product_id``
+
+  * - 23
+    - 1 (signed int)
+    - 4 (INTEGER)
+
+  * - 24
+    - 1 (signed int)
+    - 0 (NOT NULL)
+
+  * - 25
+    - 2 (signed int)
+    - 0 (size, ignored)
+
+  * - 27
+    - 2 (signed int)
+    - 0 (precision, ignored)
+
+  * - 29
+    - 1 (signed int)
+    - 7 (CHARACTER VARYING)
+
+  * - 30
+    - 1 (signed int)
+    - 0 (NOT NULL)
+
+  * - 32
+    - 2 (signed int)
+    - 64 (size)
+
+  * - 33
+    - 2 (signed int)
+    - 0 (precision, ignored)
+
+  * - 35
+    - 1 (signed int)
+    - 7 (CHARACTER VARYING)
+
+  * - 36
+    - 1 (signed int)
+    - 1 (nullable)
+
+  * - 37
+    - 2 (signed int)
+    - 1000 (size)
+
+  * - 39
+    - 2 (signed int)
+    - 0 (precision, ignored)
+
+Row Objects
+-----------
+
+The object key for a row is ``R<table>:<id>``, where *<table>* is the name of
+the table and *<id>* is a globally unique sequential integer. See
+https://github.com/elliotchance/vsql/issues/44.
+
+Within a row each of the values may be stored with a fixed or variable length.
+The length of the row is the sum of all columns.
+
+Some types that are nullable may include an extra byte on the front. If so, 0
+for ``NOT NULL`` and 1 for ``NULL``.
+
+The *Type Number* is not used in the row, but is used to identify this type for
+describing columns in a *Table Object*.
+
+.. list-table::
+  :header-rows: 1
+
+  * - Data Type
+    - Bytes
+    - Type Number
+    - Description
+
+  * - ``BOOLEAN``
+    - 1
+    - 1
+    - ``0`` (FALSE), ``1`` (TRUE), ``2`` (UNKNOWN), ``3`` (NULL)
+
+  * - ``BIGINT``
+    - 8 (NOT NULL) or 9 (nullable)
+    - 2
+    -
+
+  * - ``DOUBLE PRECISION``
+    - 8 (NOT NULL) or 9 (nullable)
+    - 3
+    - 64-bit floating point.
+
+  * - ``INTEGER``
+    - 4 (NOT NULL) or 5 (nullable)
+    - 4
+    -
+
+  * - ``REAL``
+    - 4 (NOT NULL) or 5 (nullable)
+    - 5
+    - 32-bit floating point.
+
+  * - ``SMALLINT``
+    - 2 (NOT NULL) or 3 (nullable)
+    - 6
+    -
+
+  * - ``CHARACTER VARYING``
+    - 4 + len
+    - 7
+    - ``len`` may be zero. ``-1`` is a special length to signify NULL (followed by zero bytes).
+
+  * - ``CHARACTER(n)``
+    - 4 + len
+    - 8
+    - ``len`` may only be ``-1`` (for ``NULL``) or ``n``. Values that are less then ``n`` length will be right padded with spaces.
+
+So, for example, following table:
+
+.. code-block:: sql
+
+   CREATE TABLE products (
+       product_id INT NOT NULL,
+       product_name VARCHAR(64) NOT NULL,
+       product_desc VARCHAR(1000)
+   );
+
+   INSERT INTO products (product_id, product_name, product_desc) VALUES
+     (100, 'Espresso Maker', 'Extra-large portafilter brews up to 4 shots of rich espresso');
+
+   INSERT INTO products (product_id, product_name, product_desc) VALUES
+     (200, 'Self Cleaning Juicer', NULL);
+   
+Will have the combined row layouts of 112 bytes:
+
+.. list-table::
+  :header-rows: 1
+
+  * - Byte Offset
+    - Length
+    - Value
+
+  * - 0
+    - 4 (signed 32-bit int)
+    - 100
+
+  * - 4
+    - 4 (signed 32-bit int)
+    - 14
+
+  * - 8
+    - 14 ([]byte)
+    - ``Espresso Maker``
+
+  * - 22
+    - 1 (byte)
+    - 0
+
+  * - 23
+    - 60 ([]byte)
+    - ``Extra-large portafilter brews up to 4 shots of rich espresso``
+
+  * - 83
+    - 4 (signed 32-bit int)
+    - 200
+
+  * - 87
+    - 4 (signed 32-bit int)
+    - 20
+
+  * - 91
+    - 20 ([]byte)
+    - ``Self Cleaning Juicer``
+
+  * - 111
+    - 1 (byte)
+    - 1

--- a/vsql/btree.v
+++ b/vsql/btree.v
@@ -1,0 +1,293 @@
+// btree.v implements the btree that stores all data on disk (or memory) as
+// pages. The B-tree will allocate more pages as needed, but will also shrink
+// as data is deleted.
+
+module vsql
+
+struct Btree {
+mut:
+	pager Pager
+}
+
+fn new_btree(pager Pager) &Btree {
+	return &Btree{
+		pager: pager
+	}
+}
+
+// search_page returns the traversal path to the page that either contains the
+// key, or would contain the key if it needed to be stored.
+//
+// If the key is out of bounds (before the first page or after the last page)
+// then the first or last page is returned respectively.
+//
+// The first parameter returned is the path (with each page that needs to be
+// visited and the last element being the only leaf page). The second parameter
+// is the depth iterator at each non-leaf page (so it will have a len of the
+// path - 1).
+fn (p Btree) search_page(key []byte) ?([]int, []int) {
+	// Special condition if there are no pages.
+	if p.pager.total_pages() == 0 {
+		return []int{}, []int{}
+	}
+
+	mut path := []int{}
+	mut depth_iterator := []int{}
+	mut current_page := p.pager.root_page()
+	for {
+		path << current_page
+		page := p.pager.fetch_page(current_page) ?
+
+		// Leaf node is the end of the line. The key may or may not exist, but
+		// this is the page that would contain it. In the case of adding the
+		// key, this page would be split.
+		if page.kind == kind_leaf {
+			break
+		}
+
+		// Continue to traverse through the next page. Since we need to find the
+		// greatest key that is less than the searching key it's easiest to do
+		// this backwards.
+		objects := page.objects()
+		depth_iterator << objects.len - 1
+		mut found := false
+		for depth_iterator[depth_iterator.len - 1] >= 0 {
+			if compare_bytes(key, objects[depth_iterator[depth_iterator.len - 1]].key) >= 0 {
+				current_page = bytes_to_int(objects[depth_iterator[depth_iterator.len - 1]].value)
+				found = true
+				break
+			}
+			depth_iterator[depth_iterator.len - 1]--
+		}
+
+		// Not found means that the key must exist before the first page. We
+		// return the first page but always choosing the 0th page until we hit a
+		// leaf.
+		if !found {
+			depth_iterator[depth_iterator.len - 1] = 0
+			current_page = bytes_to_int(objects[0].value)
+		}
+	}
+
+	return path, depth_iterator
+}
+
+fn (mut p Btree) add(obj PageObject) ? {
+	// First page is a special condition.
+	if p.pager.total_pages() == 0 {
+		mut page := new_page(0, p.pager.page_size())
+		page.add(obj)
+		p.pager.append_page(page) ?
+		return
+	}
+
+	// Find the page that is suitable for our insertion.
+	mut path, _ := p.search_page(obj.key) ?
+	left_page_number := path[path.len - 1]
+
+	// If we add to the page and the key is less than the page has we also
+	// need to update the parent(s). In the case of a split the minimum key will
+	// still appear in the left (same page).
+	mut page := p.pager.fetch_page(left_page_number) ?
+	previous_page_head := page.head().key.clone()
+	previous_root_page := p.pager.root_page()
+
+	// Does it fit into the desired page?
+	if page.used + obj.length() < p.pager.page_size() {
+		page.add(obj)
+		p.pager.store_page(left_page_number, page) ?
+	} else {
+		p.split_page(path, &page, obj, kind_leaf) ?
+	}
+
+	// Make sure we correct the minimum bound up the tree, if needed.
+	if compare_bytes(obj.key, previous_page_head) < 0 {
+		for path_index in 0 .. path.len - 1 {
+			mut t := p.pager.fetch_page(path[path_index]) ?
+			t.delete(previous_page_head)
+			new_object := new_page_object(obj.key.clone(), int_to_bytes(path[path_index + 1]))
+			t.add(new_object)
+			p.pager.store_page(path[path_index], t) ?
+		}
+
+		if previous_root_page != p.pager.root_page() {
+			mut new_root_page := new_page(kind_not_leaf, p.pager.page_size())
+			mut previous_objs := (p.pager.fetch_page(p.pager.root_page()) ?).objects()
+			previous_objs[0] = new_page_object(obj.key.clone(), int_to_bytes(previous_root_page))
+			new_root_page.add(previous_objs[0])
+			new_root_page.add(previous_objs[1])
+			p.pager.store_page(p.pager.root_page(), new_root_page) ?
+		}
+	}
+}
+
+fn (mut p Btree) split_page(path []int, page &Page, obj PageObject, kind byte) ? {
+	// TODO(elliotchance): We do this by dividing the number of entities, this
+	//  isn't the best since it can result in pages that aren't evenly split.
+	objects := page.objects()
+	left := objects[..objects.len / 2]
+
+	mut page1 := new_page(kind, p.pager.page_size())
+	for o in left {
+		page1.add(o)
+	}
+
+	mut page2 := new_page(kind, p.pager.page_size())
+	for o in objects[left.len..] {
+		page2.add(o)
+	}
+
+	// To maintain the sort order we need to make sure we place the new object
+	// into the correct page. That is, if the new objects key is less then the
+	// first item in the second page it must go into the first page.
+	//
+	// TODO(elliotchance): What if it doesn't fit in the page still? See
+	//  https://github.com/elliotchance/vsql/issues/43.
+	if compare_bytes(obj.key, left[left.len - 1].key) < 0 {
+		page1.add(obj)
+	} else {
+		page2.add(obj)
+	}
+
+	left_page_number := path[path.len - 1]
+	p.pager.store_page(left_page_number, page1) ?
+
+	right_page_number := p.pager.total_pages()
+	p.pager.append_page(page2) ?
+
+	// Important: The object is inserted in sorted order, so we cannot rely on
+	// the existing split values. We need to read the head object from each
+	// (potentially new) page.
+	head1 := page1.head()
+	head2 := page2.head()
+
+	p1 := new_page_object(head1.key.clone(), int_to_bytes(left_page_number))
+	p2 := new_page_object(head2.key.clone(), int_to_bytes(right_page_number))
+
+	// Try to register the new page with the parent of the left page.
+	if path.len > 1 {
+		mut page3 := p.pager.fetch_page(path[path.len - 2]) ?
+
+		// 30 is the length of p1 + p2.
+		if page3.used >= p.pager.page_size() - 30 {
+			mut new_path := path[..path.len - 1]
+			p.split_page(new_path, &page3, p2, kind_not_leaf) ?
+		} else {
+			page3.add(p2)
+			p.pager.store_page(path[path.len - 2], page3) ?
+		}
+	} else {
+		// Otherwise, we're going to need to create a new root.
+		mut page3 := new_page(kind_not_leaf, p.pager.page_size())
+		p.pager.append_page(page3) ?
+		p.pager.set_root_page(p.pager.total_pages() - 1) ?
+
+		page3.add(p1)
+		page3.add(p2)
+
+		p.pager.store_page(p.pager.root_page(), page3) ?
+	}
+}
+
+fn (p Btree) new_range_iterator(min []byte, max []byte) PageIterator {
+	return PageIterator{
+		btree: p
+		min: min
+		max: max
+	}
+}
+
+fn (mut p Btree) remove(key []byte) ? {
+	// Find the page that will contain the key, if it exists.
+	mut path, _ := p.search_page(key) ?
+	page_number := path[path.len - 1]
+	mut empty_pages := []int{}
+
+	mut page := p.pager.fetch_page(page_number) ?
+	page.delete(key)
+	p.pager.store_page(page_number, page) ?
+
+	if page.is_empty() {
+		// If the root page becomes empty we need to truncate the file.
+		if page_number == p.pager.root_page() {
+			p.pager.truncate_all() ?
+			return
+		}
+
+		empty_pages << page_number
+	}
+
+	// Update the lower boundary of all the ancestors.
+	if path.len > 1 {
+		for path_index := path.len - 2; path_index >= 0; path_index-- {
+			mut t := p.pager.fetch_page(path[path_index]) ?
+			did_delete := t.delete(key)
+
+			if !(p.pager.fetch_page(path[path_index + 1]) ?).is_empty() && did_delete {
+				lower_bound := (p.pager.fetch_page(path[path_index + 1]) ?).head().key
+				obj := new_page_object(lower_bound.clone(), int_to_bytes(path[path_index + 1]))
+				t.add(obj)
+			}
+
+			p.pager.store_page(path[path_index], t) ?
+
+			if (p.pager.fetch_page(path[path_index]) ?).is_empty() {
+				// If the root page becomes empty we need to truncate the file.
+				if path[path_index] == p.pager.root_page() {
+					p.pager.truncate_all() ?
+					return
+				}
+
+				empty_pages << path[path_index]
+			}
+		}
+	}
+
+	// I'm not sure why, but we must backfill pages starting with the last page
+	// first. Without sorting descending the b-tree stress will always crash
+	// with a handful or more size=100 trees.
+	empty_pages.sort(a > b)
+
+	// If there were any pages that are now empty we swap out the gap with the
+	// last page. This allows the file to shrink as records are deleted.
+	//
+	// TOOD(elliotchance): We might want to consider setting a threshold for
+	//  pages that become close to empty so that they can be merged with another
+	//  page. This will help the file shrink if there are a lot of scattered
+	//  deletes.
+	for empty_page in empty_pages {
+		last_page_key := (p.pager.fetch_page(p.pager.total_pages() - 1) ?).head().key
+		mut path_to_last_page, _ := p.search_page(last_page_key) ?
+
+		// The last page will be referred to somewhere in the path. We need to
+		// replace that elemenet and its immediate child.
+		for path_index in 0 .. path_to_last_page.len - 1 {
+			if path_to_last_page[path_index + 1] == p.pager.total_pages() - 1 {
+				mut ancestor := p.pager.fetch_page(path_to_last_page[path_index]) ?
+				ancestor.delete(last_page_key)
+				new_object := new_page_object(last_page_key.clone(), int_to_bytes(empty_page))
+				ancestor.add(new_object)
+				p.pager.store_page(path_to_last_page[path_index], ancestor) ?
+			}
+		}
+
+		p.pager.store_page(empty_page, p.pager.fetch_page(p.pager.total_pages() - 1) ?) ?
+
+		// Finally, truncate the last page.
+		p.pager.truncate_last_page() ?
+
+		// Be careful of moving the root page.
+		if p.pager.root_page() == p.pager.total_pages() {
+			p.pager.set_root_page(empty_page) ?
+		}
+	}
+
+	// If the root page becomes empty we need to truncate the file.
+	if (p.pager.fetch_page(p.pager.root_page()) ?).is_empty() {
+		p.pager.truncate_all() ?
+	}
+}
+
+fn (mut b Btree) close() {
+	b.pager.close()
+}

--- a/vsql/btree_test.v
+++ b/vsql/btree_test.v
@@ -1,0 +1,166 @@
+// btree_test.v provides exhustive testing for the B-tree on disk implementation
+// that cannot be tested at this scale with the existing SQL tests.
+
+module vsql
+
+import os
+import rand.util
+
+fn test_btree_test() ? {
+	// Note: When making changes to the btree (or anything that might affect
+	// it). Please pick a higher value here for more exhustive testing. Use at
+	// least 10 (ideally 100) before the final diff.
+	times := 1
+
+	for tt in 0 .. times {
+		for size := 1; size <= 1000; size *= 10 {
+			mut db_file := os.create('btree.vsql') ?
+			db_file.write([]byte{len: 256}) ?
+			db_file.close()
+			mut file_pager := new_file_pager('btree.vsql', 256) ?
+
+			run_btree_test(file_pager, size) ?
+
+			memory_pager := new_memory_pager(256)
+			run_btree_test(memory_pager, size) ?
+		}
+	}
+}
+
+fn run_btree_test(pager Pager, size int) ? {
+	mut objs := []PageObject{len: size}
+	for i in 0 .. objs.len {
+		objs[i] = PageObject{'R${i:04d}'.bytes(), []byte{len: 48}}
+	}
+
+	util.shuffle(mut objs, 0)
+
+	mut btree := new_btree(pager)
+	mut expected_objects := 0
+	for obj in objs {
+		btree.add(obj) ?
+		expected_objects++
+
+		total_leaf_objects, _ := count(pager) ?
+		assert total_leaf_objects == expected_objects
+		validate(pager) ?
+	}
+
+	mut all := []string{}
+	for object in btree.new_range_iterator('R'.bytes(), 'S'.bytes()) {
+		all << string(object.key)
+	}
+
+	assert all.len == objs.len
+	for i in 0 .. all.len {
+		assert all[i] == 'R${i:04d}'
+	}
+
+	expected_objects = objs.len
+	for obj in objs {
+		btree.remove(obj.key) ?
+		expected_objects--
+
+		total_leaf_objects, _ := count(pager) ?
+		assert total_leaf_objects == expected_objects
+		validate(pager) ?
+	}
+}
+
+fn visualize(p Pager) ? {
+	println('\n=== VISUALIZE (root = $p.root_page()) ===')
+	for i := 0; i < p.total_pages(); i++ {
+		page := p.fetch_page(i) ?
+
+		if page.kind == kind_leaf {
+			println('$i (leaf, $page.used b used): ${strkeys(page)}')
+		} else {
+			println('$i (non-leaf, $page.used b used): ${strobjects(page)}')
+		}
+	}
+
+	leaf_objects, non_leaf_objects := count(p) ?
+
+	println('total: $leaf_objects leaf + $non_leaf_objects non-leaf \n')
+}
+
+// Validate ensures that the tree is valid.
+fn validate(p Pager) ? {
+	if p.total_pages() == 0 {
+		return
+	}
+
+	validate_page(p, p.root_page()) ?
+
+	// Also make sure none of the pages become orphaned.
+	for i := 0; i < p.total_pages(); i++ {
+		page := p.fetch_page(i) ?
+
+		if page.is_empty() {
+			panic('found empty page')
+		}
+	}
+}
+
+fn validate_page(p Pager, page_number int) ?([]byte, []byte) {
+	page := p.fetch_page(page_number) ?
+	objects := page.objects()
+
+	// For any type of page the keys must be ordered.
+	mut min := objects[0].key
+	for object in objects[1..] {
+		assert compare_bytes(object.key, min) > 0
+		min = object.key
+	}
+
+	// For non-leafs we need to verify subpages are valid and consistent with
+	// the pointers.
+	if page.kind == kind_not_leaf {
+		for object in objects {
+			smallest, _ := validate_page(p, bytes_to_int(object.value)) ?
+
+			// min and max have already been verified in the subpage, but the
+			// min has to equal what our pointer says.
+			if compare_bytes(smallest, object.key) != 0 {
+				panic('${string(object.key)} in page $page_number points to ${bytes_to_int(object.value)}, but child page has head ${string(smallest)}')
+				assert false
+			}
+		}
+	}
+
+	return objects[0].key.clone(), objects[objects.len - 1].key.clone()
+}
+
+fn count(p Pager) ?(int, int) {
+	mut total_leaf_objects := 0
+	mut total_non_leaf_objects := 0
+	for i := 0; i < p.total_pages(); i++ {
+		page := p.fetch_page(i) ?
+
+		if page.kind == kind_leaf {
+			total_leaf_objects += page.keys().len
+		} else {
+			total_non_leaf_objects += page.keys().len
+		}
+	}
+
+	return total_leaf_objects, total_non_leaf_objects
+}
+
+fn strkeys(p Page) []string {
+	mut keys := []string{}
+	for object in p.objects() {
+		keys << string(object.key)
+	}
+
+	return keys
+}
+
+fn strobjects(p Page) []string {
+	mut keys := []string{}
+	for object in p.objects() {
+		keys << '${string(object.key)}:${bytes_to_int(object.value)}'
+	}
+
+	return keys
+}

--- a/vsql/bytes.v
+++ b/vsql/bytes.v
@@ -70,6 +70,7 @@ fn (mut b Bytes) read_string4() string {
 union Bytes2 {
 	bytes     [2]byte
 	i16_value i16
+	u16_value u16
 }
 
 fn (b Bytes2) bytes() []byte {
@@ -80,8 +81,12 @@ fn (mut b Bytes) write_i16(d i16) {
 	b.write_bytes(Bytes2{ i16_value: d }.bytes())
 }
 
+fn (mut b Bytes) write_u16(d u16) {
+	b.write_bytes(Bytes2{ u16_value: d }.bytes())
+}
+
 fn (mut b Bytes) write_int(x int) {
-	b.write_bytes(Bytes4{ int_value: x }.bytes())
+	b.write_bytes(int_to_bytes(x))
 }
 
 fn (mut b Bytes) read_i16() i16 {
@@ -93,13 +98,17 @@ fn (mut b Bytes) read_i16() i16 {
 	}
 }
 
-fn (mut b Bytes) read_int() int {
-	bytes := b.read_bytes(4)
+fn (mut b Bytes) read_u16() u16 {
+	bytes := b.read_bytes(2)
 	return unsafe {
-		Bytes4{
-			bytes: [bytes[0], bytes[1], bytes[2], bytes[3]]!
-		}.int_value
+		Bytes2{
+			bytes: [bytes[0], bytes[1]]!
+		}.u16_value
 	}
+}
+
+fn (mut b Bytes) read_int() int {
+	return bytes_to_int(b.read_bytes(4))
 }
 
 fn (b Bytes) bytes() []byte {
@@ -170,5 +179,19 @@ fn (mut b Bytes) read_i64() i64 {
 		Bytes8{
 			bytes: [bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]]!
 		}.i64_value
+	}
+}
+
+fn int_to_bytes(n int) []byte {
+	return Bytes4{
+		int_value: n
+	}.bytes()
+}
+
+fn bytes_to_int(bytes []byte) int {
+	return unsafe {
+		Bytes4{
+			bytes: [bytes[0], bytes[1], bytes[2], bytes[3]]!
+		}.int_value
 	}
 }

--- a/vsql/connection.v
+++ b/vsql/connection.v
@@ -6,7 +6,7 @@ module vsql
 [heap]
 pub struct Connection {
 mut:
-	storage        FileStorage
+	storage        Storage
 	funcs          map[string]Func
 	virtual_tables map[string]VirtualTable
 	query_cache    &QueryCache

--- a/vsql/delete.v
+++ b/vsql/delete.v
@@ -13,7 +13,7 @@ fn execute_delete(mut c Connection, stmt DeleteStmt, params map[string]Value, el
 	}
 
 	table := c.storage.tables[table_name]
-	mut rows := c.storage.read_rows(table.index, 0) ?
+	mut rows := c.storage.read_rows(table.name, 0) ?
 
 	mut deleted := 0
 	for row in rows {
@@ -24,7 +24,7 @@ fn execute_delete(mut c Connection, stmt DeleteStmt, params map[string]Value, el
 
 		if ok {
 			deleted++
-			c.storage.delete_row(row) ?
+			c.storage.delete_row(table.name, row) ?
 		}
 	}
 

--- a/vsql/insert.v
+++ b/vsql/insert.v
@@ -7,9 +7,7 @@ import time
 fn execute_insert(mut c Connection, stmt InsertStmt, params map[string]Value, elapsed_parse time.Duration) ?Result {
 	t := start_timer()
 
-	mut row := Row{
-		data: map[string]Value{}
-	}
+	mut row := map[string]Value{}
 
 	if stmt.columns.len < stmt.values.len {
 		return sqlstate_42601('INSERT has more values than columns')
@@ -35,12 +33,12 @@ fn execute_insert(mut c Connection, stmt InsertStmt, params map[string]Value, el
 			return sqlstate_23502('column $column_name')
 		}
 
-		row.data[column_name] = value
+		row[column_name] = value
 	}
 
 	// Fill in unspecified columns with NULL
 	for col in table.columns {
-		if col.name in row.data {
+		if col.name in row {
 			continue
 		}
 
@@ -48,10 +46,10 @@ fn execute_insert(mut c Connection, stmt InsertStmt, params map[string]Value, el
 			return sqlstate_23502('column $col.name')
 		}
 
-		row.data[col.name] = new_null_value()
+		row[col.name] = new_null_value()
 	}
 
-	c.storage.write_row(row, table) ?
+	c.storage.write_row(new_row(row), table) ?
 
 	return new_result_msg('INSERT 1', elapsed_parse, t.elapsed())
 }

--- a/vsql/page.v
+++ b/vsql/page.v
@@ -1,0 +1,143 @@
+// page.v contains the operations for manipulating a single page, such as adding
+// and removing objects.
+
+module vsql
+
+const (
+	kind_leaf     = 0 // page contains Objects.
+	kind_not_leaf = 1 // page contains links to other pages.
+)
+
+struct PageObject {
+	key   []byte
+	value []byte
+}
+
+fn new_page_object(key []byte, value []byte) PageObject {
+	return PageObject{key, value}
+}
+
+fn (o PageObject) length() int {
+	return 6 + o.key.len + o.value.len
+}
+
+fn (o PageObject) serialize() []byte {
+	mut buf := new_bytes([]byte{})
+	buf.write_int(o.length())
+	buf.write_i16(i16(o.key.len))
+	buf.write_bytes(o.key)
+	buf.write_bytes(o.value)
+
+	return buf.bytes()
+}
+
+fn parse_page_object(data []byte) (int, PageObject) {
+	mut buf := new_bytes(data)
+	total_len := buf.read_int()
+	key_len := buf.read_i16()
+
+	return total_len, new_page_object(data[6..key_len + 6].clone(), data[6 + key_len..total_len].clone())
+}
+
+struct Page {
+	kind byte // 0 = leaf, 1 = non-leaf, see constants at the top of the file.
+mut:
+	used u16    // number of bytes used by this page including 3 bytes for header.
+	data []byte // len = page size - 3
+}
+
+fn new_page(kind byte, page_size int) &Page {
+	return &Page{
+		kind: kind
+		used: 3 // includes kind and self
+		data: []byte{len: page_size - 3}
+	}
+}
+
+fn (p Page) is_empty() bool {
+	return p.used == 3
+}
+
+fn (mut p Page) add(obj PageObject) {
+	// Make sure the object is added in sorted order. This is not the most
+	// efficient way to do this. It will have to do for now.
+	mut objects := p.objects()
+	objects << obj
+
+	objects.sort_with_compare(fn (a &PageObject, b &PageObject) int {
+		return compare_bytes(a.key, b.key)
+	})
+
+	mut offset := 0
+	for object in objects {
+		s := object.serialize()
+		for i in 0 .. s.len {
+			p.data[offset] = s[i]
+			offset++
+		}
+	}
+
+	p.used += u16(obj.length())
+}
+
+// delete will remove a key from a page if it exists, otherwise no action will
+// be taken. The index of the deleted object is returned or -1.
+fn (mut p Page) delete(key []byte) bool {
+	mut offset := 0
+	mut did_delete := false
+	for object in p.objects() {
+		if compare_bytes(key, object.key) == 0 {
+			p.used -= u16(object.length())
+			did_delete = true
+			continue
+		}
+
+		s := object.serialize()
+		for i in 0 .. s.len {
+			p.data[offset] = s[i]
+			offset++
+		}
+	}
+
+	return did_delete
+}
+
+// replace will perform a delete and add operation. If the key does not exist it
+// will be created.
+fn (mut p Page) replace(key []byte, value []byte) {
+	p.delete(key)
+	obj := new_page_object(key.clone(), value)
+	p.add(obj)
+}
+
+fn (p Page) keys() [][]byte {
+	mut keys := [][]byte{}
+	for object in p.objects() {
+		keys << object.key
+	}
+
+	return keys
+}
+
+fn (p Page) objects() []PageObject {
+	mut objects := []PageObject{}
+	mut n := 0
+
+	for n < p.used - 3 {
+		// Be careful to clone the size as the underlying data might get moved
+		// around.
+		m, object := parse_page_object(p.data[n..].clone())
+		objects << object
+		n += m
+	}
+
+	return objects
+}
+
+// head returns the first object in the page, but it must only be used for
+// read only (so we can avoid the extra memory copies).
+fn (p Page) head() PageObject {
+	_, object := parse_page_object(p.data)
+
+	return object
+}

--- a/vsql/pager.v
+++ b/vsql/pager.v
@@ -1,0 +1,167 @@
+// pager.v contains the interface and implementation for a pager that stores
+// pages in memory or on disk.
+//
+// See https://github.com/elliotchance/vsql/issues/45.
+
+module vsql
+
+import os
+
+interface Pager {
+	fetch_page(page_number int) ?Page
+	store_page(page_number int, page Page) ?
+	append_page(page Page) ?
+	truncate_all() ?
+	truncate_last_page() ?
+	page_size() int
+	total_pages() int
+	root_page() int
+	set_root_page(page_number int) ?
+	close()
+}
+
+struct MemoryPager {
+	page_size int
+mut:
+	// root_page is the starting page for a traversal. The root page may change
+	// as balancing happens on the tree.
+	root_page int
+	pages     []Page
+}
+
+fn new_memory_pager(page_size int) &MemoryPager {
+	return &MemoryPager{
+		page_size: page_size
+	}
+}
+
+fn (p MemoryPager) fetch_page(page_number int) ?Page {
+	return p.pages[page_number]
+}
+
+fn (mut p MemoryPager) store_page(page_number int, page Page) ? {
+	p.pages[page_number] = page
+}
+
+fn (p MemoryPager) total_pages() int {
+	return p.pages.len
+}
+
+fn (mut p MemoryPager) append_page(page Page) ? {
+	p.pages << page
+}
+
+fn (mut p MemoryPager) truncate_all() ? {
+	p.pages = []Page{}
+}
+
+fn (mut p MemoryPager) truncate_last_page() ? {
+	p.pages = p.pages[..p.pages.len - 1]
+}
+
+fn (p MemoryPager) root_page() int {
+	return p.root_page
+}
+
+fn (mut p MemoryPager) set_root_page(page_number int) ? {
+	p.root_page = page_number
+}
+
+fn (p MemoryPager) page_size() int {
+	return p.page_size
+}
+
+fn (p MemoryPager) close() {
+}
+
+struct FilePager {
+	page_size int
+mut:
+	file        os.File
+	total_pages int
+	// root_page is the starting page for a traversal. The root page may change
+	// as balancing happens on the tree.
+	root_page int
+}
+
+// new_file_pager requires that the path already exists and has already been
+// initialized as a new database.
+fn new_file_pager(path string, page_size int) ?&FilePager {
+	mut file := os.open_file(path, 'r+') ?
+
+	file.seek(0, .end) ?
+	file_len := file.tell() ?
+
+	return &FilePager{
+		file: file
+		page_size: page_size
+		// The first page is reserved for header information. We do not include
+		// this in the pages.
+		total_pages: int(file_len / i64(page_size)) - 1
+	}
+}
+
+fn (mut p FilePager) fetch_page(page_number int) ?Page {
+	// The first page is reserved for header information. We do not include this
+	// in the pages.
+	p.file.seek(p.page_size * (page_number + 1), .start) ?
+
+	mut buf := []byte{len: p.page_size}
+	p.file.read(mut buf) ?
+
+	mut b := new_bytes(buf)
+
+	return Page{
+		kind: b.read_byte()
+		used: b.read_u16()
+		data: buf[3..]
+	}
+}
+
+fn (mut p FilePager) store_page(page_number int, page Page) ? {
+	// The first page is reserved for header information. We do not include this
+	// in the pages.
+	p.file.seek(p.page_size * (page_number + 1), .start) ?
+
+	mut b := new_bytes([]byte{})
+	b.write_byte(page.kind)
+	b.write_u16(page.used)
+	b.write_bytes(page.data)
+
+	p.file.write(b.bytes()) ?
+}
+
+fn (mut p FilePager) total_pages() int {
+	return p.total_pages
+}
+
+fn (mut p FilePager) append_page(page Page) ? {
+	// The first page is reserved for header information. We do not include this
+	// in the pages.
+	p.store_page(p.total_pages, page) ?
+	p.total_pages++
+}
+
+fn (mut p FilePager) truncate_all() ? {
+	p.total_pages = 0
+}
+
+fn (mut p FilePager) truncate_last_page() ? {
+	p.total_pages--
+}
+
+fn (p FilePager) root_page() int {
+	return p.root_page
+}
+
+fn (mut p FilePager) set_root_page(page_number int) ? {
+	p.root_page = page_number
+}
+
+fn (p FilePager) page_size() int {
+	return p.page_size
+}
+
+fn (mut p FilePager) close() {
+	p.file.close()
+}

--- a/vsql/select.v
+++ b/vsql/select.v
@@ -56,7 +56,7 @@ fn execute_select(mut c Connection, stmt SelectStmt, params map[string]Value, el
 			fetch = int((eval_as_value(c, Row{}, stmt.fetch, params) ?).f64_value)
 		}
 
-		all_rows = c.storage.read_rows(table.index, offset) ?
+		all_rows = c.storage.read_rows(table.name, offset) ?
 		if stmt.where is NoExpr {
 			if fetch >= 0 && all_rows.len > fetch {
 				all_rows = all_rows[..fetch]

--- a/vsql/storage.v
+++ b/vsql/storage.v
@@ -1,253 +1,99 @@
-// storage.v handles storing all tables and records within a single file.
-//
-// This is extremely crude and inefficient. It'll do for an initial alpha.
-// Opening an existing database requires reading the entire file to prepare the
-// table definitions and any table scan also requires reading the entire file.
-// Although, INSERTs, DELETEs and UPDATEs are O(1).
+// storage.v acts as the gateway for common operations against the raw objects
+// on from the pager, such as fetching tables and rows.
 
 module vsql
 
 import os
 
-struct FileStorage {
-	path string
+struct Storage {
 mut:
 	version i8
-	f       os.File
-	tables  map[string]Table
+	btree   Btree
+	// We keep the table definitions in memory because they are needed for most
+	// operations (including read and writing rows). All tables must be loaded
+	// when the database is opened.
+	tables map[string]Table
 }
 
-type FileStorageObject = Row | Table
-
-struct FileStorageNextObject {
-	is_eof   bool
-	category int
-	obj      FileStorageObject
-}
-
-fn new_file_storage(path string) ?FileStorage {
+fn new_file_storage(path string) ?Storage {
 	// This is a rudimentary way to ensure that small changes to storage.v are
 	// compatible as things change so rapidly. Sorry if you had a database in a
 	// previous version, you'll need to recreate it.
-	current_version := i8(3)
+	current_version := i8(4)
+
+	page_size := 4096
 
 	// If the file doesn't exist we initialize it and reopen it.
 	if !os.exists(path) {
 		mut tmpf := os.create(path) ?
 		tmpf.write_raw(current_version) ?
+		tmpf.write([]byte{len: page_size - 1}) ?
 		tmpf.close()
 	}
 
 	// Now open the prepared or existing file and read all of the table
 	// definitions.
-	mut f := FileStorage{
-		path: path
-		f: os.open_file(path, 'r+') ?
+	mut pager := new_file_pager(path, page_size) ?
+	mut f := Storage{
+		btree: new_btree(pager)
 	}
 
-	f.version = f.read<i8>() ?
+	// TODO(elliotchance): Move this to a read/write header. See
+	//  https://github.com/elliotchance/vsql/issues/42.
+	mut version := []byte{len: page_size}
+	pager.file.seek(0, .start) ?
+	pager.file.read(mut version) ?
+	f.version = i8(version[0])
+
+	// Check file version compatibility.
 	if f.version != current_version {
 		return error('need version $current_version but database is $f.version')
 	}
 
-	for {
-		next := f.read_object() ?
-		if next.is_eof {
-			break
-		}
-
-		if next.obj is Table {
-			f.tables[next.obj.name] = next.obj
-		}
+	for object in f.btree.new_range_iterator('T'.bytes(), 'U'.bytes()) {
+		table := new_table_from_bytes(object.value)
+		f.tables[table.name] = table
 	}
 
 	return f
 }
 
-fn (mut f FileStorage) read<T>() ?T {
-	return f.f.read_raw<T>()
+fn (mut f Storage) close() {
+	f.btree.close()
 }
 
-fn (mut f FileStorage) write<T>(x T) ? {
-	f.f.write_raw<T>(x) ?
-}
+fn (mut f Storage) create_table(table_name string, columns []Column) ? {
+	table := Table{table_name, columns}
 
-fn (mut f FileStorage) close() {
-	f.f.close()
-}
-
-fn (mut f FileStorage) write_value(v Value) ? {
-	f.write<SQLType>(v.typ.typ) ?
-
-	match v.typ.typ {
-		.is_null {}
-		.is_boolean, .is_double_precision, .is_bigint, .is_integer, .is_real, .is_smallint {
-			f.write<f64>(v.f64_value) ?
-		}
-		.is_varchar, .is_character {
-			f.write<int>(v.string_value.len) ?
-			for b in v.string_value.bytes() {
-				f.write<byte>(b) ?
-			}
-		}
-	}
-}
-
-fn (mut f FileStorage) read_value() ?Value {
-	typ := f.read<SQLType>() ?
-
-	return match typ {
-		.is_null {
-			new_null_value()
-		}
-		.is_boolean, .is_bigint, .is_double_precision, .is_real, .is_smallint, .is_integer {
-			Value{
-				typ: Type{typ, 0}
-				f64_value: f.read<f64>() ?
-			}
-		}
-		.is_varchar, .is_character {
-			len := f.read<int>() ?
-			mut buf := []byte{len: len}
-			f.f.read(mut buf) ?
-
-			// TODO(elliotchance): There seems to be a weird bug where
-			//  converting some bytes to a string ends up with a string that
-			//  also contains the NULL character. ie 'DOUBLE PRECISION' (16
-			//  bytes) becomes 'DOUBLE PRECISION\0' (17 bytes). The [..buf.len]
-			//  is a temporary protection against this.
-			Value{
-				typ: Type{typ, 0}
-				string_value: string(buf)[..buf.len]
-			}
-		}
-	}
-}
-
-fn sizeof_value(value Value) int {
-	return int(sizeof(SQLType) + match value.typ.typ {
-		.is_null { 0 }
-		.is_boolean, .is_double_precision, .is_integer, .is_bigint, .is_smallint, .is_real { sizeof(f64) }
-		.is_varchar, .is_character { sizeof(int) + u32(value.string_value.len) }
-	})
-}
-
-fn (mut f FileStorage) write_data_object(category int, data []byte) ? {
-	// Always ensure we append to the file.
-	f.f.seek(0, .end) ?
-
-	f.write<int>(data.len) ?
-	f.write<int>(category) ?
-	f.f.write(data) ?
-}
-
-fn (mut f FileStorage) read_object() ?FileStorageNextObject {
-	offset := u32(f.f.tell() ?)
-	data_len := f.read<int>() or {
-		// TODO(elliotchance): I'm not sure what the correcy way to detect EOF
-		//  is, but let's assume this error means the end.
-		return FileStorageNextObject{
-			is_eof: true
-		}
-	}
-	category := f.read<int>() ?
-
-	// Dead object.
-	if category == 0 {
-		mut buf := []byte{len: data_len}
-		f.f.read(mut buf) ?
-
-		return FileStorageNextObject{
-			category: category
-		}
-	}
-
-	// Table
-	if category == 1 {
-		mut buf := []byte{len: data_len}
-		f.f.read(mut buf) ?
-		table := new_table_from_bytes(buf, offset)
-
-		return FileStorageNextObject{
-			category: category
-			obj: table
-		}
-	}
-
-	// Row
-	if category >= 10000 {
-		mut table := Table{}
-		for _, t in f.tables {
-			if t.index == category - 10000 {
-				table = t
-			}
-		}
-
-		mut buf := []byte{len: data_len}
-		f.f.read(mut buf) ?
-
-		row := new_row_from_bytes(table, buf, offset)
-
-		return FileStorageNextObject{
-			category: category
-			obj: row
-		}
-	}
-
-	panic(category)
-}
-
-fn (mut f FileStorage) create_table(table_name string, columns []Column) ? {
-	index := f.tables.len + 1
-	offset := u32(f.f.tell() ?)
-
-	table := Table{offset, index, table_name, columns}
-
-	data := table.bytes()
-	f.write_data_object(1, data) ?
+	obj := new_page_object('T$table_name'.bytes(), table.bytes())
+	f.btree.add(obj) ?
 
 	f.tables[table_name] = table
 }
 
-fn (mut f FileStorage) delete_table(table_name string) ? {
-	f.f.seek(f.tables[table_name].offset, .start) ?
-
-	// If category is 0, the table (actually, the object) is deleted.
-	f.write<int>(0) ?
-
+fn (mut f Storage) delete_table(table_name string) ? {
+	f.btree.remove('T$table_name'.bytes()) ?
 	f.tables.delete(table_name)
 }
 
-fn (mut f FileStorage) delete_row(row Row) ? {
-	f.f.seek(row.offset + 4, .start) ?
-
-	// If category is 0, the table (actually, the object) is deleted.
-	f.write<int>(0) ?
+fn (mut f Storage) delete_row(table_name string, row Row) ? {
+	f.btree.remove('R$table_name:$row.id'.bytes()) ?
 }
 
-fn (mut f FileStorage) write_row(r Row, t Table) ? {
-	f.write_data_object(10000 + t.index, r.bytes(t)) ?
+fn (mut f Storage) write_row(r Row, t Table) ? {
+	obj := new_page_object('R$t.name:$r.id'.bytes(), r.bytes(t))
+	f.btree.add(obj) ?
 }
 
-fn (mut f FileStorage) read_rows(table_index int, offset int) ?[]Row {
-	f.f.seek(1, .start) ?
-
+fn (mut f Storage) read_rows(table_name string, offset int) ?[]Row {
 	mut rows := []Row{}
-	mut skipped := 0
-	for {
-		next := f.read_object() ?
-		if next.is_eof {
-			break
-		}
-
-		if next.obj is Row && next.category - 10000 == table_index {
-			if skipped < offset {
-				skipped++
-			} else {
-				rows << next.obj
-			}
-		}
+	for object in f.btree.new_range_iterator('R$table_name:'.bytes(), 'R$table_name:Z'.bytes()) {
+		rows << new_row_from_bytes(f.tables[table_name], object.value)
 	}
 
-	return rows
+	if offset >= rows.len {
+		return []Row{}
+	}
+
+	return rows[offset..]
 }

--- a/vsql/table.v
+++ b/vsql/table.v
@@ -10,8 +10,6 @@ struct Column {
 
 struct Table {
 mut:
-	offset  u32
-	index   int
 	name    string
 	columns []Column
 }
@@ -38,7 +36,6 @@ fn (t Table) column(name string) ?Column {
 fn (t Table) bytes() []byte {
 	mut b := new_bytes([]byte{})
 
-	b.write_int(t.index)
 	b.write_string1(t.name)
 
 	for col in t.columns {
@@ -52,10 +49,9 @@ fn (t Table) bytes() []byte {
 	return b.bytes()
 }
 
-fn new_table_from_bytes(data []byte, offset u32) Table {
+fn new_table_from_bytes(data []byte) Table {
 	mut b := new_bytes(data)
 
-	index := b.read_int()
 	table_name := b.read_string1()
 
 	mut columns := []Column{}
@@ -69,5 +65,5 @@ fn new_table_from_bytes(data []byte, offset u32) Table {
 		columns << Column{column_name, type_from_number(column_type), is_not_null}
 	}
 
-	return Table{offset, index, table_name, columns}
+	return Table{table_name, columns}
 }

--- a/vsql/utils.v
+++ b/vsql/utils.v
@@ -11,3 +11,24 @@ pub fn pluralize(n int, word string) string {
 
 	return '${word}s'
 }
+
+fn compare_bytes(a []byte, b []byte) int {
+	// Only compare digits to the minimum length of both.
+	min := if a.len < b.len { a.len } else { b.len }
+
+	for i in 0 .. min {
+		if a[i] != b[i] {
+			return a[i] - b[i]
+		}
+	}
+
+	// Equality probably doesn't matter for sorting, but let's check for that
+	// too.
+	if a.len == b.len {
+		return 0
+	}
+
+	// If the shared length is the same, we treat the longer string as the
+	// greater.
+	return a.len - b.len
+}

--- a/vsql/walk.v
+++ b/vsql/walk.v
@@ -1,0 +1,82 @@
+// walk.v contains the iterator that is able to walk through ranges of the
+// B-tree.
+
+module vsql
+
+struct PageIterator {
+	btree Btree
+	// min and max are inclusive.
+	min []byte
+	max []byte
+mut:
+	// objects is just for performance so we dont need to parse the objects in
+	// the page several times while we iterate that page.
+	objects []PageObject
+	// path describes the depth. At each depth is an iterator for that page.
+	path           []int
+	depth_iterator []int
+}
+
+fn (mut iter PageIterator) next() ?PageObject {
+	// Special case for no data.
+	if iter.btree.pager.total_pages() == 0 {
+		return error('')
+	}
+
+	// On the first iteration we fast-forward to the starting page.
+	if iter.path.len == 0 {
+		iter.path, iter.depth_iterator = iter.btree.search_page(iter.min) ?
+
+		// search_page does not include the last depth_iterator becuase that
+		// belongs to the leaf not which is does not search.
+		iter.depth_iterator << 0
+
+		// Load all the objects for this leaf. Making sure to skip over any keys
+		// that are out of bounds.
+		iter.objects = (iter.btree.pager.fetch_page(iter.path[iter.path.len - 1]) ?).objects()
+		for object in iter.objects {
+			// TODO(elliotchance): It would be more efficient to do a binary
+			//  search here since the page is already sorted.
+			if compare_bytes(object.key, iter.min) < 0 {
+				iter.depth_iterator[iter.depth_iterator.len - 1]++
+			}
+		}
+	}
+
+	// If this page is done, roll up to the parent and continue to traverse
+	// down.
+	if iter.depth_iterator[iter.depth_iterator.len - 1] >= iter.objects.len {
+		for {
+			if iter.path.len == 1 {
+				return error('')
+			}
+
+			iter.path = iter.path[..iter.path.len - 1]
+			iter.depth_iterator = iter.depth_iterator[..iter.depth_iterator.len - 1]
+			iter.depth_iterator[iter.depth_iterator.len - 1]++
+
+			if iter.depth_iterator[iter.depth_iterator.len - 1] < (iter.btree.pager.fetch_page(iter.path[iter.path.len - 1]) ?).objects().len {
+				break
+			}
+		}
+
+		for (iter.btree.pager.fetch_page(iter.path[iter.path.len - 1]) ?).kind == kind_not_leaf {
+			objects := (iter.btree.pager.fetch_page(iter.path[iter.path.len - 1]) ?).objects()
+
+			iter.path << bytes_to_int(objects[iter.depth_iterator[iter.depth_iterator.len - 1]].value)
+			iter.depth_iterator << 0
+		}
+
+		iter.objects = (iter.btree.pager.fetch_page(iter.path[iter.path.len - 1]) ?).objects()
+	}
+
+	o := iter.objects[iter.depth_iterator[iter.depth_iterator.len - 1]]
+	iter.depth_iterator[iter.depth_iterator.len - 1]++
+
+	// We also need to bail out if we encounter a value greater the upper bound.
+	if compare_bytes(o.key, iter.max) > 0 {
+		return error('')
+	}
+
+	return o
+}


### PR DESCRIPTION
This is an extensive refactoring and replacement of the file format to
store all objects (rows and table definitions) on disk as a B-tree.

The page size has been set at 4KB. This dicatates the minimum size
the file can grow (or shrink) by as necessary. Vacumming is not
necessary since objects are removed from the file directly and empty
pages are pruned at the time.

The algorithm for the B-tree on disk has been built by me from first
principles and stress testing. There are a ton of optimizations that
can (and should) be added soon. I have attached the new benchmark
data and done my best to document (with examples) how the structure and
operations work in the "File Format" documentation.

Perhaps before this refactoring - but only discovered through stress
testing - the default garbage collection mode (autofree) is not yet
stable enough, so you will have to use `boehm`. See "Building from
Source" in the Development documentation for more details.

There is a working memory-based pager included, but there's no way to
utilize it yet. Perhaps this can be used instead of the file-based pager
with a special ":memory:" file name (similar to the way SQLIte3 does it)
but I didn't want to make the decision in this diff, nor throw away the
in-memory implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/41)
<!-- Reviewable:end -->
