### PR TITLE
Allow in-memory database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,13 @@ jobs:
       id: v
 
     - name: Verify fmt
-      run: v fmt -verify .
+      run: make fmt-verify
 
     - name: Run SQL tests
-      run: v -stats -gc boehm -prod test vsql
+      run: make test
 
     - name: Run examples
-      run: for f in `ls examples/*.v`; do v -gc boehm -prod run $f; done
+      run: make examples
 
     - name: Set version
       if: startsWith(github.ref, 'refs/tags/')
@@ -35,7 +35,7 @@ jobs:
 
     - name: Build macOS binaries
       run: |
-        v -gc boehm -prod cmd/vsql.v
+        make vsql
         zip -j vsql-macos.zip cmd/vsql
 
     # See https://github.com/vlang/v/issues/10992

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+.PHONY: bench bench-on-disk bench-memory fmt fmt-verify test examples vsql
+
+# Binaries
+
+vsql:
+	v -gc boehm -prod cmd/vsql.v
+
+# Formatting
+
+fmt:
+	v fmt -w .
+
+fmt-verify:
+	v fmt -verify .
+
+# Tests
+
+test:
+	v -stats -gc boehm -prod test vsql
+
+# Examples
+
+examples:
+	for f in `ls examples/*.v`; do \
+		v -gc boehm -prod run $$f ; \
+	done
+
+# Benchmarking
+
+bench: bench-on-disk bench-memory
+
+bench-on-disk:
+	v -gc boehm run cmd/vsql.v bench
+
+bench-memory:
+	v -gc boehm run cmd/vsql.v bench -file ':memory:'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ no dependencies.
   - [Custom Functions](#custom-functions)
   - [Virtual Tables](#virtual-tables)
   - [Prepared Statements](https://github.com/elliotchance/vsql/blob/main/docs/prepared-statements.rst)
+  - [In Memory Databases](#in-memory-databases)
 - [FAQ](https://github.com/elliotchance/vsql/blob/main/docs/faq.rst)
 - SQL Commands
   - [CREATE TABLE](https://github.com/elliotchance/vsql/blob/main/docs/create-table.rst)
@@ -190,3 +191,12 @@ for row in result {
 The callback for the virtual table will be called repeatedly until `t.done()` is
 invoked, even if zero rows are provided in an iteration. All data will be thrown
 away between subsequent `SELECT` operations.
+
+### In Memory Databases
+
+Opening a database with the special file name ":memory:" will use an entirely
+in-memory database:
+
+```v
+mut db := vsql.open(':memory:') ?
+```

--- a/cmd/vsql.v
+++ b/cmd/vsql.v
@@ -38,6 +38,12 @@ fn main() {
 		description: 'Run benchmark'
 		execute: bench_command
 	}
+	bench_cmd.add_flag(cli.Flag{
+		flag: .string
+		name: 'file'
+		abbrev: 'f'
+		description: 'File path that will be deleted and created for the test. You can use :memory: as well (default bench.vsql)'
+	})
 	cmd.add_command(bench_cmd)
 
 	mut version_cmd := cli.Command{
@@ -96,7 +102,12 @@ fn server_command(cmd cli.Command) ? {
 fn bench_command(cmd cli.Command) ? {
 	print_version()
 
-	mut conn := vsql.open('bench.vsql') or { panic('$err') }
+	mut file := cmd.flags.get_string('file') or { '' }
+	if file == '' {
+		file = 'bench.vsql'
+	}
+
+	mut conn := vsql.open(':memory:') or { panic('$err') }
 
 	mut benchmark := vsql.new_benchmark(conn)
 	benchmark.start() or { panic('$err') }
@@ -104,7 +115,13 @@ fn bench_command(cmd cli.Command) ? {
 
 fn print_version() {
 	// This constant is replaced at build time. See ci.yml.
-	println('vsql MISSING_VERSION')
+	version := 'MISSING_VERSION'
+
+	// For local development we don't want to print the version if it's not set.
+	// Be careful not to use the constant value again as it will be replaced.
+	if !version.contains('MISSING') {
+		println('vsql $version')
+	}
 }
 
 fn version_command(cmd cli.Command) ? {

--- a/docs/benchmark.rst
+++ b/docs/benchmark.rst
@@ -7,6 +7,12 @@ are already a wide array of products out there that are battled tested and tuned
 to perfection. This page is useful to compare the relative performance
 improvements between releases.
 
+Use the follow command to run the on-disk and memory benchmarks:
+
+.. code-block:: sh
+
+   make bench
+
 .. contents::
 
 Process
@@ -76,26 +82,31 @@ These were run on:
 - 2.3 GHz Quad-Core Intel Core i7
 - 16 GB 1600 MHz DDR3
 
-.. list-table::
-  :header-rows: 1
+**INSERT** and **SELECT** are in rows per second and **TCP-B** is in transactions per second.
 
-  * - Date
-    - Version
-    - INSERT (rows/s)
-    - SELECT (rows/s)
-    - TCP-B (tps)
-    - Notes
++------------+---------+-------------------------+-------------------------+-------+
+|            |         | On-disk                 | In-memory               |       |
+| Date       | Version +--------+--------+-------+--------+--------+-------+ Notes |
+|            |         | INSERT | SELECT | TCP-B | INSERT | SELECT | TCP-B |       |
++============+=========+========+========+=======+========+========+=======+=======+
+| 2021-09-15 | v0.12.1 | 378    | 65256  | 0.376 | 270    | 71851  | 0.396 | [3]_  |
++------------+---------+--------+--------+-------+--------+--------+-------+-------+
+| 2021-09-15 | v0.12.1 | 355    | 71851  | 0.377 |        |        |       | [2]_  |
++------------+---------+--------+--------+-------+--------+--------+-------+-------+
+| 2021-09-04 | v0.12.0 | 5107   | 129252 | 0.378 |        |        |       | [1]_  |
++------------+---------+--------+--------+-------+--------+--------+-------+-------+
 
-  * - 2021-09-04
-    - `v0.11.0 <https://github.com/elliotchance/vsql/releases/tag/v0.11.0>`_
-    - 5107
-    - 129252
-    - 0.378
-    - This first version of the storage format is basically a binary CSV. Where tables and rows are treated as objects in a stream. That is, to find a record is to read (and decode) all rows from every table.
+.. [3] This version introduces an in-memory option, but no changes were made to
+   functionality. The on-disk and in-memory performance is similar because the
+   OS does a very good job at cashing random access reads and writes.
 
-  * - 2021-09-15
-    - `v0.12.0 <https://github.com/elliotchance/vsql/releases/tag/v0.12.0>`_
-    - 355
-    - 71851
-    - 0.377
-    - This version completely replaces the storage engine with with a B-tree on disk. Although the ``INSERT`` and ``SELECT`` speeds are much lower, the same transaction throughput is retained because it no longer has to scan the full file for any ``SELECT`` operation. The current implementation uses a 4kb page, but leaves a lot of low hanging fruit for optimization, however, this version only focused on functionalty and not performance.
+.. [2] This version completely replaces the storage engine with with a B-tree on
+   disk. Although the ``INSERT`` and ``SELECT`` speeds are much lower, the same
+   transaction throughput is retained because it no longer has to scan the full
+   file for any ``SELECT`` operation. The current implementation uses a 4kb
+   page, but leaves a lot of low hanging fruit for optimization, however, this
+   version only focused on functionalty and not performance.
+
+.. [1] This first version of the storage format is basically a binary CSV. Where
+   tables and rows are treated as objects in a stream. That is, to find a record
+   is to read (and decode) all rows from every table.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -24,6 +24,16 @@ If you receive an error, you may need to install it on macOS:
 
   brew install libgc
 
+Debugging
+---------
+
+Termination signals often don't give much context, you can get more information
+by using the ``lldb`` debugger:
+
+.. code-block:: sh
+
+   v examples/memory.v && lldb -o run examples/memory
+
 Parser & SQL Grammar
 --------------------
 

--- a/examples/memory.v
+++ b/examples/memory.v
@@ -1,0 +1,22 @@
+import vsql
+
+fn main() {
+	example() or { panic(err) }
+}
+
+fn example() ? {
+	mut db := vsql.open(':memory:') ?
+
+	// All SQL commands use query():
+	db.query('CREATE TABLE foo (x DOUBLE PRECISION)') ?
+	db.query('INSERT INTO foo (x) VALUES (1.23)') ?
+	db.query('INSERT INTO foo (x) VALUES (4.56)') ?
+
+	// Iterate through a result:
+	result := db.query('SELECT * FROM foo') ?
+	println(result.columns)
+
+	for row in result {
+		println(row.get_f64('X') ?)
+	}
+}

--- a/vsql/btree.v
+++ b/vsql/btree.v
@@ -291,3 +291,7 @@ fn (mut p Btree) remove(key []byte) ? {
 fn (mut b Btree) close() {
 	b.pager.close()
 }
+
+fn (mut b Btree) flush() {
+	b.pager.flush()
+}

--- a/vsql/pager.v
+++ b/vsql/pager.v
@@ -18,6 +18,7 @@ interface Pager {
 	root_page() int
 	set_root_page(page_number int) ?
 	close()
+	flush()
 }
 
 struct MemoryPager {
@@ -72,6 +73,9 @@ fn (p MemoryPager) page_size() int {
 }
 
 fn (p MemoryPager) close() {
+}
+
+fn (p MemoryPager) flush() {
 }
 
 struct FilePager {
@@ -164,4 +168,8 @@ fn (p FilePager) page_size() int {
 
 fn (mut p FilePager) close() {
 	p.file.close()
+}
+
+fn (mut p FilePager) flush() {
+	p.file.flush()
 }

--- a/vsql/sql_test.v
+++ b/vsql/sql_test.v
@@ -79,14 +79,11 @@ fn get_tests() ?[]SQLTest {
 fn test_all() ? {
 	query_cache := new_query_cache()
 	for test in get_tests() ? {
-		path := '/tmp/test.vsql'
-		if os.exists(path) {
-			os.rm(path) ?
-		}
-
 		mut options := default_connection_options()
 		options.query_cache = query_cache
-		mut db := open_database(path, options) ?
+
+		// Use an in-memory database because it's much faster.
+		mut db := open_database(':memory:', options) ?
 
 		register_pg_functions(mut db) ?
 

--- a/vsql/storage.v
+++ b/vsql/storage.v
@@ -3,8 +3,6 @@
 
 module vsql
 
-import os
-
 struct Storage {
 mut:
 	version i8
@@ -15,39 +13,9 @@ mut:
 	tables map[string]Table
 }
 
-fn new_file_storage(path string) ?Storage {
-	// This is a rudimentary way to ensure that small changes to storage.v are
-	// compatible as things change so rapidly. Sorry if you had a database in a
-	// previous version, you'll need to recreate it.
-	current_version := i8(4)
-
-	page_size := 4096
-
-	// If the file doesn't exist we initialize it and reopen it.
-	if !os.exists(path) {
-		mut tmpf := os.create(path) ?
-		tmpf.write_raw(current_version) ?
-		tmpf.write([]byte{len: page_size - 1}) ?
-		tmpf.close()
-	}
-
-	// Now open the prepared or existing file and read all of the table
-	// definitions.
-	mut pager := new_file_pager(path, page_size) ?
+fn new_storage(pager Pager) ?Storage {
 	mut f := Storage{
 		btree: new_btree(pager)
-	}
-
-	// TODO(elliotchance): Move this to a read/write header. See
-	//  https://github.com/elliotchance/vsql/issues/42.
-	mut version := []byte{len: page_size}
-	pager.file.seek(0, .start) ?
-	pager.file.read(mut version) ?
-	f.version = i8(version[0])
-
-	// Check file version compatibility.
-	if f.version != current_version {
-		return error('need version $current_version but database is $f.version')
 	}
 
 	for object in f.btree.new_range_iterator('T'.bytes(), 'U'.bytes()) {
@@ -60,6 +28,10 @@ fn new_file_storage(path string) ?Storage {
 
 fn (mut f Storage) close() {
 	f.btree.close()
+}
+
+fn (mut f Storage) flush() {
+	f.btree.flush()
 }
 
 fn (mut f Storage) create_table(table_name string, columns []Column) ? {


### PR DESCRIPTION
Opening a database with the file ":memory:" will now use an entirely
in-memory pager. This can also be used with the "bench" by using the
new option `-file :memory` or more simply `make bench-memory`.

Curiously, the updated benchmarks don't show much difference between
on-disk and in-memory, so I guess the OS is doing a very good job with
caching random access reads and writes. Even after making sure all
changes are flushed to disk at the end of each query.

Tests will now use an in-memory database, which on my machine shaves off
about 13% of the execution time.

Added a Makefile to help standardize and simplfy commands for
development and CI.

Fixes #45

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/47)
<!-- Reviewable:end -->
