### PR TITLE
Fix open() concurrency in goroutines

### DIFF
--- a/docs/benchmark.rst
+++ b/docs/benchmark.rst
@@ -89,6 +89,8 @@ These were run on:
 | Date       | Version +--------+--------+-------+--------+--------+-------+ Notes |
 |            |         | INSERT | SELECT | TCP-B | INSERT | SELECT | TCP-B |       |
 +============+=========+========+========+=======+========+========+=======+=======+
+| 2021-10-04 | v0.14.2 | 974    | 65775  | 97    | 939    | 64267  | 97    | [5]_  |
++------------+---------+--------+--------+-------+--------+--------+-------+-------+
 | 2021-09-19 | v0.14.0 | 995    | 61782  | 94    | 992    | 62253  | 91    | [4]_  |
 +------------+---------+--------+--------+-------+--------+--------+-------+-------+
 | 2021-09-15 | v0.12.1 | 378    | 65256  | 0.376 | 270    | 71851  | 0.396 | [3]_  |
@@ -97,6 +99,15 @@ These were run on:
 +------------+---------+--------+--------+-------+--------+--------+-------+-------+
 | 2021-09-04 | v0.11.0 | 5107   | 129252 | 0.378 |        |        |       | [1]_  |
 +------------+---------+--------+--------+-------+--------+--------+-------+-------+
+
+.. [5] The recent two patches focused on fixes to do with concurrent read/write
+   to the same file. This is critical general reliability and for transactions
+   (coming soon). Fortunately, the added locking mechanics did not have any
+   serious impact on performance. Which is a bit surprising since readers and
+   writers have to always check if the schema has changed on the file
+   underneath. Or, perhaps, it was just some inadvertent optimizations that were
+   introduced when simplifying the abstraction layers and lifecycle between
+   Connection/Storage/Btree/Pager/File.
 
 .. [4] Now we can utilize a PRIMARY KEY on the table which the query planner
    understands for exact matches (which we use in these benchmarks). This

--- a/vsql/connection.v
+++ b/vsql/connection.v
@@ -4,6 +4,7 @@
 module vsql
 
 import os
+import sync
 
 [heap]
 pub struct Connection {
@@ -21,15 +22,32 @@ mut:
 	query_cache &QueryCache
 	// options are used when aquiring each file connection.
 	options ConnectionOptions
-	// file is a copy of the file handle opened by the pager so that we can
-	// release the lock.
-	file os.File
 }
 
+// open is the convenience function for open_database() with default options.
 pub fn open(path string) ?Connection {
 	return open_database(path, default_connection_options())
 }
 
+// open_database will open an existing database file or create a new file if the
+// path does not exist.
+//
+// If the file does exist, open_database will assume that the file is a valid
+// database file (not corrupt). Otherwise unexpected behavior or even a crash
+// may occur.
+//
+// The special file name ":memory:" can be used to create an entirely in-memory
+// database. This will be faster but all data will be lost when the connection
+// is closed.
+//
+// open_database can be used concurrently for reading and writing to the same
+// file and provides the following default protections:
+//
+// - Fine: Multiple processes open_database() the same file.
+// - Fine: Multiple goroutines sharing an open_database() on the same file.
+// - Bad: Multiple goroutines open_database() the same file.
+//
+// See ConnectionOptions and default_connection_options().
 pub fn open_database(path string, options ConnectionOptions) ?Connection {
 	if path == ':memory:' {
 		return open_connection(path, options)
@@ -48,10 +66,11 @@ fn open_connection(path string, options ConnectionOptions) ?Connection {
 		path: path
 		query_cache: options.query_cache
 		options: options
+		storage: new_storage()
 	}
 
 	if path == ':memory:' {
-		conn.storage = new_storage(new_memory_pager(options.page_size)) ?
+		conn.storage.btree = new_btree(new_memory_pager(), options.page_size)
 	}
 
 	register_builtin_funcs(mut conn) ?
@@ -64,13 +83,10 @@ fn (mut c Connection) open_read_connection() ? {
 		return
 	}
 
-	mut pager := new_file_pager(c.path, c.options.page_size) ?
-	c.file = pager.file
+	c.options.mutex.@rlock()
 
-	c.storage = new_storage(pager) ?
-	flock_lock_shared(c.file)
-
-	c.storage.load_schema() ?
+	flock_lock_shared(c.storage.file)
+	c.storage.open(c.path) ?
 }
 
 fn (mut c Connection) open_write_connection() ? {
@@ -78,24 +94,40 @@ fn (mut c Connection) open_write_connection() ? {
 		return
 	}
 
-	mut pager := new_file_pager(c.path, c.options.page_size) ?
-	c.file = pager.file
+	c.options.mutex.@lock()
 
-	c.storage = new_storage(pager) ?
-	flock_lock_exclusive(c.file)
-
-	c.storage.load_schema() ?
+	flock_lock_exclusive(c.storage.file)
+	c.storage.open(c.path) ?
 }
 
-fn (mut c Connection) release_connection() {
+fn (mut c Connection) release_write_connection() {
 	if c.path == ':memory:' {
 		return
 	}
 
-	c.storage.flush()
-	c.storage.close()
+	c.storage.close() or {
+		// This was a hack to get around the fact we can't return an option from
+		// this function because it messes with the behavior of defer.
+		panic(err)
+	}
 
-	flock_unlock(c.file)
+	flock_unlock_exclusive(c.storage.file)
+	c.options.mutex.unlock()
+}
+
+fn (mut c Connection) release_read_connection() {
+	if c.path == ':memory:' {
+		return
+	}
+
+	c.storage.close() or {
+		// This was a hack to get around the fact we can't return an option from
+		// this function because it messes with the behavior of defer.
+		panic(err)
+	}
+
+	flock_unlock_shared(c.storage.file)
+	c.options.mutex.runlock()
 }
 
 pub fn (mut c Connection) prepare(sql string) ?PreparedStmt {
@@ -108,9 +140,6 @@ pub fn (mut c Connection) prepare(sql string) ?PreparedStmt {
 
 pub fn (mut c Connection) query(sql string) ?Result {
 	mut prepared := c.prepare(sql) ?
-	defer {
-		c.storage.flush()
-	}
 
 	return prepared.query(map[string]Value{})
 }
@@ -155,15 +184,43 @@ pub fn (mut c Connection) register_virtual_table(create_table string, data fn (m
 
 struct ConnectionOptions {
 pub mut:
+	// query_cache contains the precompiled prepared statements that can be
+	// reused. This makes execution much faster as parsing the SQL is extremely
+	// expensive.
+	//
+	// By default each connection will be given its own query cache. However,
+	// you can safely share a single cache over multiple connections and you are
+	// encouraged to do so.
 	query_cache &QueryCache
 	// Warning: This only works for :memory: databases. Configuring it for
 	// file-based databases will either be ignored or causes crashes.
 	page_size int
+	// In short, vsql (with default options) when dealing with concurrent
+	// read/write access to single file provides the following protections:
+	//
+	// - Fine: Multiple processes open() the same file.
+	// - Fine: Multiple goroutines sharing an open() on the same file.
+	// - Bad: Multiple goroutines open() the same file.
+	//
+	// The mutex option will protect against the third Bad case if you
+	// provide the same mutex instance to all open() calls:
+	//
+	//   mutex := sync.new_rwmutex() // only create one of these
+	//
+	//   mut options := default_connection_options()
+	//   options.mutex = mutex
+	//
+	// Since locking all database isn't ideal. You could provide a consistent
+	// RwMutex that belongs to each file - such as from a map.
+	mutex &sync.RwMutex
 }
 
+// default_connection_options returns the sensible defaults used by open() and
+// the correct base to provide your own option overrides. See ConnectionOptions.
 fn default_connection_options() ConnectionOptions {
 	return ConnectionOptions{
 		query_cache: new_query_cache()
 		page_size: 4096
+		mutex: sync.new_rwmutex()
 	}
 }

--- a/vsql/connection_test.v
+++ b/vsql/connection_test.v
@@ -1,24 +1,39 @@
 module vsql
 
 import os
+import sync
 
 fn test_concurrent_writes() ? {
+	verbose_env := $env('VERBOSE')
+	verbose := verbose_env != ''
+
 	file_name := 'test_concurrent_writes.vsql'
 	if os.exists(file_name) {
 		os.rm(file_name) ?
 	}
 
-	mut db := open(file_name) ?
+	// A shared mutex is required if we intend to open_database() to the same
+	// file within multiple goroutines. See ConnectionOptions.
+	mut options := default_connection_options()
+	options.mutex = sync.new_rwmutex()
+
+	mut db := open_database(file_name, options) ?
 	db.query('CREATE TABLE foo (x INT)') ?
 
 	mut waits := []thread{}
 	for i in 0 .. 10 {
-		waits << go fn (file_name string) {
-			mut db := open(file_name) or { panic(err) }
-			for i in 0 .. 10 {
+		waits << go fn (file_name string, verbose bool, i int, options ConnectionOptions) {
+			mut db := open_database(file_name, options) or { panic(err) }
+			for j in 0 .. 100 {
+				if verbose {
+					println('${i}.$j: INSERT start')
+				}
 				db.query('INSERT INTO foo (x) VALUES (1)') or { panic(err) }
+				if verbose {
+					println('${i}.$j: INSERT done')
+				}
 			}
-		}(file_name)
+		}(file_name, verbose, i, options)
 	}
 	waits.wait()
 
@@ -28,5 +43,5 @@ fn test_concurrent_writes() ? {
 		total += int(row.get_f64('X') ?)
 	}
 
-	assert total == 100
+	assert total == 1000
 }

--- a/vsql/create_table.v
+++ b/vsql/create_table.v
@@ -11,7 +11,7 @@ fn execute_create_table(mut c Connection, stmt CreateTableStmt, elapsed_parse ti
 
 	c.open_write_connection() ?
 	defer {
-		c.release_connection()
+		c.release_write_connection()
 	}
 
 	table_name := identifier_name(stmt.table_name)

--- a/vsql/flock.v
+++ b/vsql/flock.v
@@ -1,5 +1,8 @@
-// flock.v contains file locking functions. This likely only works on *nix
-// systems.
+// flock.v contains file locking functions. flock() itself only protects against
+// concurrent access from different processes, so to protect against goroutines
+// we need to add an additional level of locking within this process.
+//
+// TODO(elliotchance) This likely only works on *nix systems.
 
 module vsql
 
@@ -9,14 +12,18 @@ import os
 
 fn C.flock(int, int) int
 
-fn flock_lock_exclusive(f os.File) {
-	C.flock(f.fd, C.LOCK_EX)
+fn flock_lock_exclusive(file os.File) {
+	C.flock(file.fd, C.LOCK_EX)
 }
 
-fn flock_lock_shared(f os.File) {
-	C.flock(f.fd, C.LOCK_SH)
+fn flock_lock_shared(file os.File) {
+	C.flock(file.fd, C.LOCK_SH)
 }
 
-fn flock_unlock(f os.File) {
-	C.flock(f.fd, C.LOCK_UN)
+fn flock_unlock_exclusive(file os.File) {
+	C.flock(file.fd, C.LOCK_UN)
+}
+
+fn flock_unlock_shared(file os.File) {
+	C.flock(file.fd, C.LOCK_UN)
 }

--- a/vsql/header.v
+++ b/vsql/header.v
@@ -20,12 +20,29 @@ mut:
 	// that prevents connections (even if there is only one) from needing to
 	// reread the schema if it has not changed.
 	schema_version int
+	// The page_size is always set to 4kb (4096 bytes). It's possible we can
+	// make this configurable in the future, but for now changing it may break
+	// stuff.
+	page_size int
+	// The root_page is the virtual page number (not including the header) of
+	// the page that is the top of the B-tree. This may move around (potentially
+	// anywhere in the file) as the root page needs to be divided or merged -
+	// although this should be quite infrequent.
+	root_page int
+}
+
+fn new_header(page_size int) Header {
+	return Header{
+		// Set all default here - even if they are zero - to be explicit.
+		version: vsql.current_version
+		schema_version: 0
+		page_size: page_size
+		root_page: 0
+	}
 }
 
 fn init_database_file(path string, page_size int) ? {
-	header := Header{
-		version: vsql.current_version
-	}
+	header := new_header(page_size)
 
 	mut tmpf := os.create(path) ?
 	write_header(mut tmpf, header) ?

--- a/vsql/insert.v
+++ b/vsql/insert.v
@@ -9,7 +9,7 @@ fn execute_insert(mut c Connection, stmt InsertStmt, params map[string]Value, el
 
 	c.open_write_connection() ?
 	defer {
-		c.release_connection()
+		c.release_write_connection()
 	}
 
 	mut row := map[string]Value{}

--- a/vsql/select.v
+++ b/vsql/select.v
@@ -9,7 +9,7 @@ fn execute_select(mut c Connection, stmt SelectStmt, params map[string]Value, el
 
 	c.open_read_connection() ?
 	defer {
-		c.release_connection()
+		c.release_read_connection()
 	}
 
 	plan := create_plan(stmt, params, c) ?

--- a/vsql/storage.v
+++ b/vsql/storage.v
@@ -1,31 +1,44 @@
 // storage.v acts as the gateway for common operations against the raw objects
 // on from the pager, such as fetching tables and rows.
+//
+// Storage is maintained over individual operations on the file because it
+// caches the schema.
 
 module vsql
 
+import os
+
 struct Storage {
 mut:
-	version i8
-	// schema_version determines if the schema needs to be reloaded.
-	schema_version int
-	btree          Btree
+	header Header
+	// btree is replaced for each operation (because it needs a new pager for
+	// each operation).
+	btree Btree
 	// We keep the table definitions in memory because they are needed for most
 	// operations (including read and writing rows). All tables must be loaded
 	// when the database is opened.
 	tables map[string]Table
+	// file is opened, flushed and closed with each operation against the file.
+	file os.File
 }
 
-fn new_storage(pager Pager) ?Storage {
-	mut f := Storage{
-		btree: new_btree(pager)
+fn new_storage() Storage {
+	return Storage{}
+}
+
+fn (mut f Storage) open(path string) ? {
+	f.file = os.open_file(path, 'r+') ?
+
+	header := read_header(mut f.file) ?
+	defer {
+		f.header = header
 	}
 
-	return f
-}
+	f.btree = new_btree(new_file_pager(mut f.file, header.page_size, header.root_page) ?,
+		header.page_size)
 
-fn (mut f Storage) load_schema() ? {
-	current_schema_version := f.btree.pager.schema_version() ?
-	if current_schema_version == f.schema_version {
+	// Avoid reloading the schema if it hasn't change.
+	if header.schema_version == f.header.schema_version {
 		return
 	}
 
@@ -35,16 +48,26 @@ fn (mut f Storage) load_schema() ? {
 		table := new_table_from_bytes(object.value)
 		f.tables[table.name] = table
 	}
-
-	f.schema_version = current_schema_version
 }
 
-fn (mut f Storage) close() {
-	f.btree.close()
+fn (mut f Storage) schema_changed() {
+	// We don't need to read the header again because write operations on a file
+	// are exclusive so the version (and the header itself) we already have can
+	// be incremented.
+	f.header.schema_version++
 }
 
-fn (mut f Storage) flush() {
-	f.btree.flush()
+fn (mut f Storage) close() ? {
+	// Before closing the connection we always write back the page header in
+	// case the schema_version or root_page have changed.
+	//
+	// TODO(elliotchance): We should be smarter about only writing this when we
+	//  need to.
+	f.header.root_page = f.btree.pager.root_page()
+	write_header(mut f.file, f.header) ?
+
+	f.file.flush()
+	f.file.close()
 }
 
 fn (mut f Storage) create_table(table_name string, columns []Column, primary_key []string) ? {
@@ -54,13 +77,13 @@ fn (mut f Storage) create_table(table_name string, columns []Column, primary_key
 	f.btree.add(obj) ?
 
 	f.tables[table_name] = table
-	f.btree.pager.schema_changed() ?
+	f.schema_changed()
 }
 
 fn (mut f Storage) delete_table(table_name string) ? {
 	f.btree.remove('T$table_name'.bytes()) ?
 	f.tables.delete(table_name)
-	f.btree.pager.schema_changed() ?
+	f.schema_changed()
 }
 
 fn (mut f Storage) delete_row(table_name string, mut row Row) ? {

--- a/vsql/update.v
+++ b/vsql/update.v
@@ -9,7 +9,7 @@ fn execute_update(mut c Connection, stmt UpdateStmt, params map[string]Value, el
 
 	c.open_write_connection() ?
 	defer {
-		c.release_connection()
+		c.release_write_connection()
 	}
 
 	plan := create_plan(stmt, params, c) ?


### PR DESCRIPTION
In short, vsql (with the default options) when dealing with concurrent
read/write access to single file provides the following protections:

- Fine: Multiple processes open() the same file.
- Fine: Multiple goroutines sharing an open() on the same file.
- Bad: Multiple goroutines open() the same file.

The connection_test.v fell into the last category. It's interesting it
wasn't picked up by local testing or CI (at least on the first run
before it was merged).

The test has now been updated to use the new "mutex" option and
increased from 10 goroutines x 10 records to 10 goroutines x 100
records.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/62)
<!-- Reviewable:end -->
