### PR TITLE
btree: Support transaction IDs

### DIFF
--- a/vsql/connection.v
+++ b/vsql/connection.v
@@ -25,7 +25,7 @@ mut:
 }
 
 // open is the convenience function for open_database() with default options.
-pub fn open(path string) ?Connection {
+pub fn open(path string) ?&Connection {
 	return open_database(path, default_connection_options())
 }
 
@@ -48,7 +48,7 @@ pub fn open(path string) ?Connection {
 // - Bad: Multiple goroutines open_database() the same file.
 //
 // See ConnectionOptions and default_connection_options().
-pub fn open_database(path string, options ConnectionOptions) ?Connection {
+pub fn open_database(path string, options ConnectionOptions) ?&Connection {
 	if path == ':memory:' {
 		return open_connection(path, options)
 	}
@@ -61,8 +61,8 @@ pub fn open_database(path string, options ConnectionOptions) ?Connection {
 	return open_connection(path, options)
 }
 
-fn open_connection(path string, options ConnectionOptions) ?Connection {
-	mut conn := Connection{
+fn open_connection(path string, options ConnectionOptions) ?&Connection {
+	mut conn := &Connection{
 		path: path
 		query_cache: options.query_cache
 		options: options

--- a/vsql/delete.v
+++ b/vsql/delete.v
@@ -6,6 +6,12 @@ import time
 
 fn execute_delete(mut c Connection, stmt DeleteStmt, params map[string]Value, elapsed_parse time.Duration, explain bool) ?Result {
 	t := start_timer()
+
+	c.open_write_connection() ?
+	defer {
+		c.release_write_connection()
+	}
+
 	mut plan := create_plan(stmt, params, c) ?
 
 	if explain {

--- a/vsql/drop_table.v
+++ b/vsql/drop_table.v
@@ -6,13 +6,20 @@ import time
 
 fn execute_drop_table(mut c Connection, stmt DropTableStmt, elapsed_parse time.Duration) ?Result {
 	t := start_timer()
+
+	c.open_write_connection() ?
+	defer {
+		c.release_write_connection()
+	}
+
 	table_name := identifier_name(stmt.table_name)
 
 	if table_name !in c.storage.tables {
 		return sqlstate_42p01(table_name) // table does not exist
 	}
 
-	// TODO(elliotchance): Also delete rows.
+	// TODO(elliotchance): Also delete rows. See
+	//  https://github.com/elliotchance/vsql/issues/65.
 	c.storage.delete_table(table_name) ?
 
 	return new_result_msg('DROP TABLE 1', elapsed_parse, t.elapsed())

--- a/vsql/header.v
+++ b/vsql/header.v
@@ -7,7 +7,7 @@ import os
 // This is a rudimentary way to ensure that small changes to storage.v are
 // compatible as things change so rapidly. Sorry if you had a database in a
 // previous version, you'll need to recreate it.
-const current_version = i8(5)
+const current_version = i8(6)
 
 // The Header contains important metadata about the database and always occupies
 // the first page of the database.

--- a/vsql/page.v
+++ b/vsql/page.v
@@ -4,26 +4,47 @@
 module vsql
 
 const (
-	kind_leaf     = 0 // page contains Objects.
-	kind_not_leaf = 1 // page contains links to other pages.
+	kind_leaf     = 0 // page contains only objects.
+	kind_not_leaf = 1 // page contains only links to other pages.
 )
 
+// page_object_prefix_length is the precalculated length that will be the
+// combination of all fixed width meta for the page object.
+const page_object_prefix_length = 14
+
 struct PageObject {
-	key   []byte
+	// The key is not required to be unique in the page. It becomes unique when
+	// combined with tid. However, no more than two version of the same key can
+	// exist in a page. See the caveats at the top of btree.v.
+	key []byte
+	// The value contains the serialized data for the object. The first byte of
+	// key is used to both identify what type of object this is and also keep
+	// objects within the same collection also within the same range.
 	value []byte
+mut:
+	// The tid is the transaction that created the object.
+	//
+	// TODO(elliotchance): It makes more sense to construct a new PageObject
+	//  when changing the tid and xid.
+	tid int
+	// The xid is the transaciton that deleted the object, or zero if it has
+	// never been deleted.
+	xid int
 }
 
-fn new_page_object(key []byte, value []byte) PageObject {
-	return PageObject{key, value}
+fn new_page_object(key []byte, tid int, xid int, value []byte) PageObject {
+	return PageObject{key, value, tid, xid}
 }
 
 fn (o PageObject) length() int {
-	return 6 + o.key.len + o.value.len
+	return vsql.page_object_prefix_length + o.key.len + o.value.len
 }
 
 fn (o PageObject) serialize() []byte {
 	mut buf := new_bytes([]byte{})
 	buf.write_int(o.length())
+	buf.write_int(o.tid)
+	buf.write_int(o.xid)
 	buf.write_i16(i16(o.key.len))
 	buf.write_bytes(o.key)
 	buf.write_bytes(o.value)
@@ -34,9 +55,13 @@ fn (o PageObject) serialize() []byte {
 fn parse_page_object(data []byte) (int, PageObject) {
 	mut buf := new_bytes(data)
 	total_len := buf.read_int()
+	tid := buf.read_int()
+	xid := buf.read_int()
 	key_len := buf.read_i16()
 
-	return total_len, new_page_object(data[6..key_len + 6].clone(), data[6 + key_len..total_len].clone())
+	return total_len, new_page_object(data[vsql.page_object_prefix_length..key_len +
+		vsql.page_object_prefix_length].clone(), tid, xid, data[vsql.page_object_prefix_length +
+		key_len..total_len].clone())
 }
 
 struct Page {
@@ -58,10 +83,37 @@ fn (p Page) is_empty() bool {
 	return p.used == 3
 }
 
-fn (mut p Page) add(obj PageObject) {
+fn (p Page) page_size() int {
+	return p.data.len + 3
+}
+
+// add will append the object (in order of key) or return an error if either the
+// object cannot fit or there already exists two versions of the key.
+fn (mut p Page) add(obj PageObject) ? {
+	if p.used + obj.length() > p.page_size() {
+		return error('page cannot fit object')
+	}
+
+	// TODO(elliotchance): Checking for existence is just a safety measure for
+	//  now and should be wasted CPU. The MVCC logic that creates the extra
+	//  version should prevent more than two versions from being created anyway.
+	//  Try removing this in the future when transaction are well tested and
+	//  stable.
+	mut objects := p.objects()
+	mut versions := 0
+	for object in objects {
+		if compare_bytes(object.key, obj.key) == 0 {
+			versions++
+
+			// Check for two (since we're about to add a third).
+			if versions == 2 {
+				return error('more than two versions is not allowed')
+			}
+		}
+	}
+
 	// Make sure the object is added in sorted order. This is not the most
 	// efficient way to do this. It will have to do for now.
-	mut objects := p.objects()
 	objects << obj
 
 	objects.sort_with_compare(fn (a &PageObject, b &PageObject) int {
@@ -82,11 +134,11 @@ fn (mut p Page) add(obj PageObject) {
 
 // delete will remove a key from a page if it exists, otherwise no action will
 // be taken. The index of the deleted object is returned or -1.
-fn (mut p Page) delete(key []byte) bool {
+fn (mut p Page) delete(key []byte, tid int) bool {
 	mut offset := 0
 	mut did_delete := false
 	for object in p.objects() {
-		if compare_bytes(key, object.key) == 0 {
+		if compare_bytes(key, object.key) == 0 && object.tid == tid {
 			p.used -= u16(object.length())
 			did_delete = true
 			continue
@@ -102,12 +154,33 @@ fn (mut p Page) delete(key []byte) bool {
 	return did_delete
 }
 
+// expire will set the expiry transaction ID on an existing object. True is
+// returned if the page was modified.
+fn (mut p Page) expire(key []byte, tid int, xid int) bool {
+	mut offset := 0
+	mut modified := false
+	for mut object in p.objects() {
+		if compare_bytes(key, object.key) == 0 && object.tid == tid {
+			object.xid = xid
+			modified = true
+		}
+
+		s := object.serialize()
+		for i in 0 .. s.len {
+			p.data[offset] = s[i]
+			offset++
+		}
+	}
+
+	return modified
+}
+
 // replace will perform a delete and add operation. If the key does not exist it
 // will be created.
-fn (mut p Page) replace(key []byte, value []byte) {
-	p.delete(key)
-	obj := new_page_object(key.clone(), value)
-	p.add(obj)
+fn (mut p Page) replace(key []byte, tid int, value []byte) ? {
+	p.delete(key, tid)
+	obj := new_page_object(key.clone(), tid, 0, value)
+	p.add(obj) ?
 }
 
 fn (p Page) keys() [][]byte {

--- a/vsql/sql_test.v
+++ b/vsql/sql_test.v
@@ -19,7 +19,6 @@ fn get_tests() ?[]SQLTest {
 		if env_test != '' && !test_file_path.contains(env_test) {
 			continue
 		}
-
 		lines := os.read_lines(test_file_path) ?
 
 		mut stmts := []string{}
@@ -109,7 +108,7 @@ fn run_single_test(test SQLTest, query_cache &QueryCache, verbose bool) ? {
 	// The default connection is called "main". The docs explain that "main"
 	// should not be referenced in tests and the "connection" directive must
 	// be the first line in the test.
-	mut connections := map[string]Connection{}
+	mut connections := map[string]&Connection{}
 	mut current_connection_name := ''
 
 	file_name := 'test.vsql'

--- a/vsql/storage.v
+++ b/vsql/storage.v
@@ -73,7 +73,7 @@ fn (mut f Storage) close() ? {
 fn (mut f Storage) create_table(table_name string, columns []Column, primary_key []string) ? {
 	table := Table{table_name, columns, primary_key}
 
-	obj := new_page_object('T$table_name'.bytes(), table.bytes())
+	obj := new_page_object('T$table_name'.bytes(), 0, 0, table.bytes())
 	f.btree.add(obj) ?
 
 	f.tables[table_name] = table
@@ -81,17 +81,23 @@ fn (mut f Storage) create_table(table_name string, columns []Column, primary_key
 }
 
 fn (mut f Storage) delete_table(table_name string) ? {
-	f.btree.remove('T$table_name'.bytes()) ?
+	// TODO(elliotchance): This is wrong because we should expire (not delete)
+	//  and the tid needs to be maintained on the row.
+	f.btree.remove('T$table_name'.bytes(), 0) ?
+
 	f.tables.delete(table_name)
 	f.schema_changed()
 }
 
 fn (mut f Storage) delete_row(table_name string, mut row Row) ? {
-	f.btree.remove(row.object_key(f.tables[table_name]) ?) ?
+	// TODO(elliotchance): This is wrong because we should expire (not delete)
+	//  and the tid needs to be maintained on the row.
+	f.btree.remove(row.object_key(f.tables[table_name]) ?, 0) ?
 }
 
 fn (mut f Storage) write_row(mut r Row, t Table) ? {
-	obj := new_page_object(r.object_key(t) ?, r.bytes(t))
+	// TODO(elliotchance): The real tid needs to be provided.
+	obj := new_page_object(r.object_key(t) ?, 0, 0, r.bytes(t))
 	f.btree.add(obj) ?
 }
 


### PR DESCRIPTION
This refactors the B-tree and paging implementation from only supporting unique keys across the entire tree to now supporting the created/expired transaction IDs as well as allowing for multiple versions of a key.

This is a breaking change to the file format. I decided to do this as an intermediate step because the diff for transaction was getting really large and complex. Implementing the isolation logic now will be easier and I can feel more confident that the B-tree is well tested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/68)
<!-- Reviewable:end -->
