### PR TITLE
Fix "more than two versions is not allowed"

### DIFF
--- a/docs/sqlstate.rst
+++ b/docs/sqlstate.rst
@@ -95,6 +95,24 @@ already active transaction.
    START TRANSACTION;
    -- error 25001: invalid transaction state: active sql transaction
 
+``25P02`` in failed sql transaction
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``25P02`` will be returned for all commands within a transaction after a failure
+of a previous SQL statement. You must ``COMMIT`` or ``ROLLBACK``, however,
+``COMMIT`` will be treated as a ``ROLLBACK``.
+
+**Examples**
+
+.. code-block:: sql
+
+   CREATE TABLE foo (b BOOLEAN);
+   INSERT INTO foo (b) VALUES (123, 456);
+   SELECT * FROM foo;
+   -- msg: CREATE TABLE 1
+   -- error 42601: syntax error: INSERT has more values than columns
+   -- error 25P02: transaction is aborted, commands ignored until end of transaction block
+
 ``2D000`` invalid transaction termination
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -109,6 +127,16 @@ in an active transaction.
    COMMIT;
    COMMIT;
    -- error 2D000: invalid transaction termination
+
+``40001`` serialization failure
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``40001`` occurs if concurrent transactions attempt to update the same row. If
+allowed, this would lead to an inconsistency. It's possible that this also might
+be a deadlock in some situations. However, the deadlock is always avoided
+because the current transaction that receives this error will be rolled back.
+
+A client that receives this error should retry the transaction.
 
 ``42601`` syntax error
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/update.rst
+++ b/docs/update.rst
@@ -23,3 +23,16 @@ EXPLAIN
 
 The query planner will decide the best strategy to execute the ``UPDATE``. You
 can see this plan by using the ``EXPLAIN`` prefix. See :doc:`explain`.
+
+Errors
+------
+
+Only one transaction is allowed to hold a modified version of a record at one
+time. This allows all other transactions to see the previous (frozen) version
+and the in-flight transaction to see it's own version.
+
+It's not possible for multiple in-flight transactions to hold different versions
+of the same semantic row. This would break the serialization rules of the
+transaction since this would cause a conflict as to whos version is "correct".
+This situation will return a SQLSTATE 40001 "serialization failure" error.
+Clients that receive this error should start the entire transaction again.

--- a/tests/isolation-read-committed.sql
+++ b/tests/isolation-read-committed.sql
@@ -148,3 +148,51 @@ SELECT * FROM foo;
 -- 1: msg: INSERT 1
 -- 2: msg: UPDATE 0
 -- 1: BAR: 123
+
+/* connection 1 */
+CREATE TABLE foo (bar INT);
+INSERT INTO foo (bar) VALUES (123);
+START TRANSACTION;
+UPDATE foo SET bar = 456;
+SELECT * FROM foo;
+/* connection 2 */
+START TRANSACTION;
+UPDATE foo SET bar = 789;
+SELECT * FROM foo;
+/* connection 1 */
+SELECT * FROM foo;
+-- 1: msg: CREATE TABLE 1
+-- 1: msg: INSERT 1
+-- 1: msg: START TRANSACTION
+-- 1: msg: UPDATE 1
+-- 1: BAR: 456
+-- 2: msg: START TRANSACTION
+-- 2: error 40001: serialization failure: avoiding concurrent write on individual row
+-- 2: error 25P02: transaction is aborted, commands ignored until end of transaction block
+-- 1: BAR: 456
+
+/* connection 1 */
+CREATE TABLE foo (bar INT);
+INSERT INTO foo (bar) VALUES (123);
+START TRANSACTION;
+UPDATE foo SET bar = 456;
+UPDATE foo SET bar = 789;
+UPDATE foo SET bar = 234;
+SELECT * FROM foo;
+/* connection 2 */
+START TRANSACTION;
+UPDATE foo SET bar = 345;
+SELECT * FROM foo;
+/* connection 1 */
+SELECT * FROM foo;
+-- 1: msg: CREATE TABLE 1
+-- 1: msg: INSERT 1
+-- 1: msg: START TRANSACTION
+-- 1: msg: UPDATE 1
+-- 1: msg: UPDATE 1
+-- 1: msg: UPDATE 1
+-- 1: BAR: 234
+-- 2: msg: START TRANSACTION
+-- 2: error 40001: serialization failure: avoiding concurrent write on individual row
+-- 2: error 25P02: transaction is aborted, commands ignored until end of transaction block
+-- 1: BAR: 234

--- a/tests/transaction.sql
+++ b/tests/transaction.sql
@@ -87,3 +87,18 @@ SELECT * FROM foo;
 -- 2: msg: START TRANSACTION
 -- 2: msg: DROP TABLE 1
 -- 2: error 42P01: no such table: FOO
+
+CREATE TABLE foo (b BOOLEAN);
+INSERT INTO foo (b) VALUES (123, 456);
+SELECT * FROM foo;
+-- msg: CREATE TABLE 1
+-- error 42601: syntax error: INSERT has more values than columns
+
+START TRANSACTION;
+CREATE TABLE foo (b BOOLEAN);
+INSERT INTO foo (b) VALUES (123, 456);
+SELECT * FROM foo;
+-- msg: START TRANSACTION
+-- msg: CREATE TABLE 1
+-- error 42601: syntax error: INSERT has more values than columns
+-- error 25P02: transaction is aborted, commands ignored until end of transaction block

--- a/tests/update.sql
+++ b/tests/update.sql
@@ -26,8 +26,8 @@ SELECT * FROM foo;
 -- msg: INSERT 1
 -- msg: UPDATE 1
 -- msg: UPDATE 0
--- BAZ: 78
 -- BAZ: 100
+-- BAZ: 78
 
 CREATE TABLE foo (baz FLOAT);
 UPDATE foo SET baz = true;

--- a/vsql/bench.v
+++ b/vsql/bench.v
@@ -84,6 +84,8 @@ fn (mut b Benchmark) run_transaction() ? {
 	tid := b.random(1, b.teller_rows)
 	delta := b.random(-5000, 5000)
 
+	b.conn.query('START TRANSACTION') ?
+
 	b.conn.query('UPDATE accounts SET abalance = abalance + $delta WHERE aid = $aid') ?
 	b.conn.query('SELECT abalance FROM accounts WHERE aid = $aid') ?
 	b.conn.query('UPDATE tellers SET tbalance = tbalance + $delta WHERE tid = $tid') ?
@@ -91,6 +93,8 @@ fn (mut b Benchmark) run_transaction() ? {
 
 	// TODO(elliotchance): Should use CURRENT_TIMESTAMP once supported.
 	b.conn.query('INSERT INTO history (tid, bid, aid, delta, mtime) VALUES ($tid, $bid, $aid, $delta, \'$time.now()\')') ?
+
+	b.conn.query('COMMIT') ?
 }
 
 fn (b Benchmark) random(min int, max int) int {

--- a/vsql/prepare.v
+++ b/vsql/prepare.v
@@ -23,6 +23,13 @@ mut:
 }
 
 pub fn (mut p PreparedStmt) query(params map[string]Value) ?Result {
+	return p.query_internal(params) or {
+		p.c.storage.transaction_aborted()
+		return err
+	}
+}
+
+fn (mut p PreparedStmt) query_internal(params map[string]Value) ?Result {
 	mut all_params := params.clone()
 	for k, v in p.params {
 		if k !in all_params {

--- a/vsql/sqlstate.v
+++ b/vsql/sqlstate.v
@@ -225,3 +225,29 @@ fn sqlstate_0b000(msg string) IError {
 		msg: 'invalid transaction initiation: $msg'
 	}
 }
+
+// serialization failure
+struct SQLState40001 {
+	msg  string
+	code int
+}
+
+fn sqlstate_40001(message string) IError {
+	return SQLState40001{
+		code: sqlstate_to_int('40001')
+		msg: 'serialization failure: $message'
+	}
+}
+
+// in failed sql transaction
+struct SQLState25P02 {
+	msg  string
+	code int
+}
+
+fn sqlstate_25p02() IError {
+	return SQLState25P02{
+		code: sqlstate_to_int('25P02')
+		msg: 'transaction is aborted, commands ignored until end of transaction block'
+	}
+}

--- a/vsql/storage.v
+++ b/vsql/storage.v
@@ -8,6 +8,18 @@ module vsql
 
 import os
 
+enum TransactionState {
+	not_active
+	// Whilst in a transaction (specifically START TRANSACTION, not an implicit
+	// transaction). This is important to stop a nested transaction from
+	// starting or closing an unstarted transaction.
+	active
+	// If transaction_state is .aborted, all SQL statements will return a
+	// SQLSTATE 25P02 until a COMMIT or ROLLBACK is issued. Also, in this state
+	// a COMMIT will be treated as a ROLLBACK.
+	aborted
+}
+
 struct Storage {
 mut:
 	header Header
@@ -20,11 +32,8 @@ mut:
 	tables map[string]Table
 	// file is opened, flushed and closed with each operation against the file.
 	file os.File
-	// in_transaction will be true whilst in a transaction (specifically
-	// START TRANSACTION, not an implicit transaction). This is important to
-	// stop a nested transaction from starting or closing an unstarted
-	// transaction.
-	in_transaction bool
+	// See TransactionState for docs.
+	transaction_state TransactionState
 	// transaction_id is the current active transaction ID, or zero if there is
 	// no active transaction. If there is no active transaction, each statement
 	// will be given an implicit transaction.
@@ -60,7 +69,7 @@ fn (mut f Storage) open(path string) ? {
 	// belong to an active transaction.
 	f.isolation_start() ?
 	defer {
-		f.isolation_end()
+		f.isolation_end() or { panic(err) }
 	}
 
 	for object in f.btree.new_range_iterator('T'.bytes(), 'U'.bytes()) {
@@ -95,7 +104,7 @@ fn (mut f Storage) close() ? {
 fn (mut f Storage) create_table(table_name string, columns []Column, primary_key []string) ? {
 	f.isolation_start() ?
 	defer {
-		f.isolation_end()
+		f.isolation_end() or { panic(err) }
 	}
 
 	table := Table{table_name, columns, primary_key, f.transaction_id}
@@ -111,10 +120,12 @@ fn (mut f Storage) create_table(table_name string, columns []Column, primary_key
 fn (mut f Storage) delete_table(table_name string, tid int) ? {
 	f.isolation_start() ?
 	defer {
-		f.isolation_end()
+		f.isolation_end() or { panic(err) }
 	}
 
-	f.btree.expire('T$table_name'.bytes(), tid, f.transaction_id) ?
+	page_number := f.btree.expire('T$table_name'.bytes(), tid, f.transaction_id) ?
+	f.transaction_pages[page_number] = true
+
 	f.tables.delete(table_name)
 	f.schema_changed()
 }
@@ -122,16 +133,17 @@ fn (mut f Storage) delete_table(table_name string, tid int) ? {
 fn (mut f Storage) delete_row(table_name string, mut row Row) ? {
 	f.isolation_start() ?
 	defer {
-		f.isolation_end()
+		f.isolation_end() or { panic(err) }
 	}
 
-	f.btree.expire(row.object_key(f.tables[table_name]) ?, row.tid, f.transaction_id) ?
+	page_number := f.btree.expire(row.object_key(f.tables[table_name]) ?, row.tid, f.transaction_id) ?
+	f.transaction_pages[page_number] = true
 }
 
 fn (mut f Storage) write_row(mut r Row, t Table) ? {
 	f.isolation_start() ?
 	defer {
-		f.isolation_end()
+		f.isolation_end() or { panic(err) }
 	}
 
 	obj := new_page_object(r.object_key(t) ?, f.transaction_id, 0, r.bytes(t))
@@ -139,10 +151,23 @@ fn (mut f Storage) write_row(mut r Row, t Table) ? {
 	f.transaction_pages[page_number] = true
 }
 
+fn (mut f Storage) update_row(mut old Row, mut new Row, t Table) ? {
+	f.isolation_start() ?
+	defer {
+		f.isolation_end() or { panic(err) }
+	}
+
+	old_obj := new_page_object(old.object_key(t) ?, old.tid, 0, old.bytes(t))
+	new_obj := new_page_object(new.object_key(t) ?, f.transaction_id, 0, new.bytes(t))
+	for page_number in f.btree.update(old_obj, new_obj, f.transaction_id) ? {
+		f.transaction_pages[page_number] = true
+	}
+}
+
 fn (mut f Storage) read_rows(table_name string, offset int) ?[]Row {
 	f.isolation_start() ?
 	defer {
-		f.isolation_end()
+		f.isolation_end() or { panic(err) }
 	}
 
 	mut rows := []Row{}
@@ -166,8 +191,16 @@ fn (mut f Storage) read_rows(table_name string, offset int) ?[]Row {
 // transaction will be created. Otherwise, this isolation block will be part of
 // the current transaction.
 fn (mut f Storage) isolation_start() ? {
-	if f.in_transaction {
-		return
+	match f.transaction_state {
+		.not_active {
+			// Fallthrough to the logic below.
+		}
+		.active {
+			return
+		}
+		.aborted {
+			return sqlstate_25p02()
+		}
 	}
 
 	f.header.transaction_id++
@@ -176,16 +209,42 @@ fn (mut f Storage) isolation_start() ? {
 	f.header.active_transaction_ids.add(f.transaction_id) ?
 }
 
+fn (mut f Storage) transaction_aborted() {
+	if f.transaction_state == .active {
+		f.transaction_state = .aborted
+	}
+}
+
 // isolation_end must be called at some point after isolation_start to signal
 // the end of the atomic blocks. At the moment blocks cannot be nested so the
 // state of the active or implicit transaction state is expected to be
 // maintained.
-fn (mut f Storage) isolation_end() {
-	if f.in_transaction {
-		// Do nothing. COMMIT, ROLLBACK or some other transaction terminator
-		// will take care of this later.
-		return
+fn (mut f Storage) isolation_end() ? {
+	match f.transaction_state {
+		.not_active {
+			// Fallthrough to logic below.
+		}
+		.active, .aborted {
+			// Do nothing. COMMIT, ROLLBACK or some other transaction terminator
+			// will take care of this later.
+			return
+		}
 	}
+
+	// Revist any remaining pages to clean out any expired rows.
+	for page_number, _ in f.transaction_pages {
+		mut page := f.btree.pager.fetch_page(page_number) ?
+		for obj in page.objects() {
+			// Only remove the objects expired in this transaction.
+			if obj.xid == f.transaction_id {
+				page.delete(obj.key, obj.tid)
+			}
+		}
+
+		f.btree.pager.store_page(page_number, page) ?
+	}
+
+	f.transaction_pages = map[int]bool{}
 
 	f.header.active_transaction_ids.remove(f.transaction_id)
 }

--- a/vsql/update.v
+++ b/vsql/update.v
@@ -1,4 +1,17 @@
 // update.v contains the implementation for the UPDATE statement.
+//
+// UPDATE under MVCC works by actually executing a DELETE and an INSERT on the
+// record to be updated. There are two important caveats for this:
+//
+// 1. If there is already two versions that exist for the record, UPDATE will
+// return a SQLSTATE 40001 serialization failure to prevent multiple in-flight
+// transactions form holding different modified version of the same semantic
+// row. Clients that receive this error should retry the entire transaction.
+//
+// 2. If there are two versions that exist for a record but the in-flight
+// version that exists belongs to this transaction we must avoid the
+// DELETE/INSERT and only update the specific version that belongs to this
+// transaction.
 
 module vsql
 
@@ -36,11 +49,18 @@ fn execute_update(mut c Connection, stmt UpdateStmt, params map[string]Value, el
 		}
 	}
 
-	mut delete_rows := []Row{}
-	mut new_rows := []Row{}
+	mut modify_count := 0
 	for mut row in rows {
 		mut did_modify := false
+
+		// When creating a new row make sure we also carry across the internal
+		// ID. This allows the underlying storage to indentify it as a different
+		// version of the same semantic row. We also need to maintain the
+		// original tid for the storage to know which version is frozen.
 		mut row2 := new_row(row.data.clone())
+		row2.id = row.id
+		row2.tid = row.tid
+
 		for k, v in stmt.set {
 			column_name := identifier_name(k)
 			table_column := table.column(column_name) ?
@@ -64,18 +84,10 @@ fn execute_update(mut c Connection, stmt UpdateStmt, params map[string]Value, el
 		}
 
 		if did_modify {
-			delete_rows << row
-			new_rows << row2
+			modify_count++
+			c.storage.update_row(mut row, mut row2, table) ?
 		}
 	}
 
-	for mut row in delete_rows {
-		c.storage.delete_row(table_name, mut row) ?
-	}
-
-	for mut row in new_rows {
-		c.storage.write_row(mut row, table) ?
-	}
-
-	return new_result_msg('UPDATE $new_rows.len', elapsed_parse, t.elapsed())
+	return new_result_msg('UPDATE $modify_count', elapsed_parse, t.elapsed())
 }


### PR DESCRIPTION
This error was reported from "make bench" and is caused by concurrent
transactions attempting to modify the same record. This is disallowed
because it would break the serialization rules of a transaction.

Normally (in a server environment) it might block the second transaction
until the in-flight row becomes frozen (returns to a single version) -
then be able to proceed (only in some isolation modes). However, this is
not as trivial in a share-nothing architecture (as least not right now).
So, a proper (new) SQLSTATE 40001 "serialization failure" is returned
instead. Clients that receive this must restart the transaction again.

Better reporting of error is not the bug. The actual bug is why the
error is raised in the first place, since "make bench" runs sequential
transactions that should never happen. This was caused by UPDATE
(which was a DELETE/INSERT) underneath not being able to handle the case
where the record to be updated is the in-flight version and not the
frozen version. So, in a nutshell, UPDATE was in some cases just trying to
always create a new version.

This also fixes another related bug where implicit transactions were not
revisiting pages to perform the neeccesary cleanup (like that which
happens on a COMMIT/ROLLBACK) also potentially leaving expired versions
behind.

Furthemore, a SQLSTATE 25P02 "in failed sql transaction" is returned for
all statements after an error is returned during a transaction, until a
COMMIT or ROLLBACK is issued also triggering the correct cleanup.

Fixes #74

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/75)
<!-- Reviewable:end -->
