### PR TITLE
Adding LIKE expression

### DIFF
--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -36,3 +36,30 @@ IS NULL
   X IS [ NOT ] NULL
 
 Tests if ``X`` is (or is not) ``NULL``.
+
+LIKE
+----
+
+.. code-block:: text
+
+  X [ NOT ] LIKE Y
+
+Tests if ``X`` matches the like-expression of ``Y``. Apart from simple regexp
+matching, this is very useful for testing the prefix or suffix of a string.
+
+Matching is always against the entire string (not a partial match) and is
+case-sensitive. You can use the following characters in ``Y``:
+
+- ``_`` matches any single character.
+- ``%`` matches zero, one or more characters.
+
+*Examples*
+
+.. code-block:: sql
+
+  'a' LIKE 'a'          -- TRUE
+  'a' LIKE 'A'          -- FALSE
+  'ab' LIKE 'a_'        -- TRUE
+  'abc' LIKE 'a_'       -- FALSE
+  'acdeb' LIKE 'a%b'    -- TRUE
+  'abc' NOT LIKE 'a%'   -- FALSE

--- a/grammar.bnf
+++ b/grammar.bnf
@@ -274,6 +274,7 @@
 <predicate> /* Expr */ ::=
     <comparison predicate>
   | <between predicate>
+  | <like predicate>
   | <null predicate>
 
 <comparison predicate> /* Expr */ ::=
@@ -776,3 +777,16 @@
 
 <row subquery> /* QueryExpression */ ::=
     <subquery>
+
+<character like predicate part 2> /* LikeExpr */ ::=
+    LIKE <character pattern>       -> like
+  | NOT LIKE <character pattern>   -> not_like
+
+<character pattern> /* Expr */ ::=
+    <character value expression>
+
+<character like predicate> /* Expr */ ::=
+    <row value predicand> <character like predicate part 2>   -> like_pred
+
+<like predicate> /* Expr */ ::=
+    <character like predicate>

--- a/tests/like.sql
+++ b/tests/like.sql
@@ -1,0 +1,56 @@
+EXPLAIN VALUES 'a' LIKE 'a';
+-- EXPLAIN: VALUES (COL1 BOOLEAN) = ROW('a' LIKE 'a')
+
+VALUES 'a' LIKE 'a';
+-- COL1: TRUE
+
+VALUES 'a' LIKE 'A';
+-- COL1: FALSE
+
+VALUES 'a' LIKE 'aa';
+-- COL1: FALSE
+
+VALUES 'ab' LIKE 'a_';
+-- COL1: TRUE
+
+VALUES 'ab' NOT LIKE 'a_';
+-- COL1: FALSE
+
+VALUES 'abc' LIKE 'a_';
+-- COL1: FALSE
+
+VALUES 'abc' LIKE '_b_';
+-- COL1: TRUE
+
+VALUES 'abc' LIKE '%';
+-- COL1: TRUE
+
+VALUES 'abc' LIKE 'a%';
+-- COL1: TRUE
+
+VALUES 'abc' NOT LIKE 'a%';
+-- COL1: FALSE
+
+VALUES 'a' LIKE 'a%';
+-- COL1: TRUE
+
+VALUES 'ba' LIKE 'a%';
+-- COL1: FALSE
+
+VALUES 'ab' LIKE 'a%b';
+-- COL1: TRUE
+
+VALUES 'acb' LIKE 'a%b';
+-- COL1: TRUE
+
+VALUES 'acdeb' LIKE 'a%b';
+-- COL1: TRUE
+
+VALUES 'ab' NOT LIKE 'a%b';
+-- COL1: FALSE
+
+VALUES 'acb' NOT LIKE 'a%b';
+-- COL1: FALSE
+
+VALUES 'acdeb' NOT LIKE 'a%b';
+-- COL1: FALSE

--- a/vsql/ast.v
+++ b/vsql/ast.v
@@ -20,6 +20,7 @@ type Expr = BetweenExpr
 	| BinaryExpr
 	| CallExpr
 	| Identifier
+	| LikeExpr
 	| NoExpr
 	| NullExpr
 	| Parameter
@@ -45,6 +46,9 @@ fn (e Expr) pstr(params map[string]Value) string {
 		}
 		Identifier {
 			e.str()
+		}
+		LikeExpr {
+			e.pstr(params)
 		}
 		NoExpr {
 			e.str()
@@ -365,4 +369,19 @@ fn (e RowExpr) pstr(params map[string]Value) string {
 	}
 
 	return 'ROW(${values.join(', ')})'
+}
+
+// LikeExpr for "LIKE" and "NOT LIKE".
+struct LikeExpr {
+	left  Expr
+	right Expr
+	not   bool
+}
+
+fn (e LikeExpr) pstr(params map[string]Value) string {
+	if e.not {
+		return '${e.left.pstr(params)} NOT LIKE ${e.right.pstr(params)}'
+	}
+
+	return '${e.left.pstr(params)} LIKE ${e.right.pstr(params)}'
 }

--- a/vsql/grammar.v
+++ b/vsql/grammar.v
@@ -12,6 +12,7 @@ type EarleyValue = BetweenExpr
 	| Expr
 	| Identifier
 	| InsertStmt
+	| LikeExpr
 	| QueryExpression
 	| SelectList
 	| SimpleTable
@@ -160,6 +161,24 @@ fn get_grammar() map[string]EarleyRule {
 	}
 	mut rule_character_length_ := &EarleyRule{
 		name: '<character length>'
+	}
+	mut rule_character_like_predicate_part_2_1_ := &EarleyRule{
+		name: '<character like predicate part 2: 1>'
+	}
+	mut rule_character_like_predicate_part_2_2_ := &EarleyRule{
+		name: '<character like predicate part 2: 2>'
+	}
+	mut rule_character_like_predicate_part_2_ := &EarleyRule{
+		name: '<character like predicate part 2>'
+	}
+	mut rule_character_like_predicate_1_ := &EarleyRule{
+		name: '<character like predicate: 1>'
+	}
+	mut rule_character_like_predicate_ := &EarleyRule{
+		name: '<character like predicate>'
+	}
+	mut rule_character_pattern_ := &EarleyRule{
+		name: '<character pattern>'
 	}
 	mut rule_character_position_expression_1_ := &EarleyRule{
 		name: '<character position expression: 1>'
@@ -553,6 +572,9 @@ fn get_grammar() map[string]EarleyRule {
 	}
 	mut rule_less_than_or_equals_operator_ := &EarleyRule{
 		name: '<less than or equals operator>'
+	}
+	mut rule_like_predicate_ := &EarleyRule{
+		name: '<like predicate>'
 	}
 	mut rule_literal_2_ := &EarleyRule{
 		name: '<literal: 2>'
@@ -1184,6 +1206,9 @@ fn get_grammar() map[string]EarleyRule {
 	mut rule_key := &EarleyRule{
 		name: 'KEY'
 	}
+	mut rule_like := &EarleyRule{
+		name: 'LIKE'
+	}
 	mut rule_ln := &EarleyRule{
 		name: 'LN'
 	}
@@ -1729,6 +1754,59 @@ fn get_grammar() map[string]EarleyRule {
 	rule_character_length_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_length_
+		},
+	]}
+
+	rule_character_like_predicate_part_2_1_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_like
+		},
+		&EarleyRuleOrString{
+			rule: rule_character_pattern_
+		},
+	]}
+
+	rule_character_like_predicate_part_2_2_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_not
+		},
+		&EarleyRuleOrString{
+			rule: rule_like
+		},
+		&EarleyRuleOrString{
+			rule: rule_character_pattern_
+		},
+	]}
+
+	rule_character_like_predicate_part_2_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_character_like_predicate_part_2_1_
+		},
+	]}
+	rule_character_like_predicate_part_2_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_character_like_predicate_part_2_2_
+		},
+	]}
+
+	rule_character_like_predicate_1_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_row_value_predicand_
+		},
+		&EarleyRuleOrString{
+			rule: rule_character_like_predicate_part_2_
+		},
+	]}
+
+	rule_character_like_predicate_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_character_like_predicate_1_
+		},
+	]}
+
+	rule_character_pattern_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_character_value_expression_
 		},
 	]}
 
@@ -2980,6 +3058,12 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
+	rule_like_predicate_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_character_like_predicate_
+		},
+	]}
+
 	rule_literal_2_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_general_literal_
@@ -3457,6 +3541,11 @@ fn get_grammar() map[string]EarleyRule {
 	rule_predicate_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_between_predicate_
+		},
+	]}
+	rule_predicate_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_like_predicate_
 		},
 	]}
 	rule_predicate_.productions << &EarleyProduction{[
@@ -4923,6 +5012,13 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
+	rule_like.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			str: 'LIKE'
+			rule: 0
+		},
+	]}
+
 	rule_ln.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			str: 'LN'
@@ -5225,6 +5321,12 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<char length expression>'] = rule_char_length_expression_
 	rules['<character factor>'] = rule_character_factor_
 	rules['<character length>'] = rule_character_length_
+	rules['<character like predicate part 2: 1>'] = rule_character_like_predicate_part_2_1_
+	rules['<character like predicate part 2: 2>'] = rule_character_like_predicate_part_2_2_
+	rules['<character like predicate part 2>'] = rule_character_like_predicate_part_2_
+	rules['<character like predicate: 1>'] = rule_character_like_predicate_1_
+	rules['<character like predicate>'] = rule_character_like_predicate_
+	rules['<character pattern>'] = rule_character_pattern_
 	rules['<character position expression: 1>'] = rule_character_position_expression_1_
 	rules['<character position expression>'] = rule_character_position_expression_
 	rules['<character primary>'] = rule_character_primary_
@@ -5356,6 +5458,7 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<length>'] = rule_length_
 	rules['<less than operator>'] = rule_less_than_operator_
 	rules['<less than or equals operator>'] = rule_less_than_or_equals_operator_
+	rules['<like predicate>'] = rule_like_predicate_
 	rules['<literal: 2>'] = rule_literal_2_
 	rules['<literal>'] = rule_literal_
 	rules['<local or schema qualified name>'] = rule_local_or_schema_qualified_name_
@@ -5566,6 +5669,7 @@ fn get_grammar() map[string]EarleyRule {
 	rules['INTO'] = rule_into
 	rules['IS'] = rule_is
 	rules['KEY'] = rule_key
+	rules['LIKE'] = rule_like
 	rules['LN'] = rule_ln
 	rules['LOG10'] = rule_log10
 	rules['MOD'] = rule_mod
@@ -5724,6 +5828,17 @@ fn parse_ast_name(children []EarleyValue, name string) ?[]EarleyValue {
 		}
 		'<char length expression: 2>' {
 			return [EarleyValue(parse_char_length(children[2] as Expr) ?)]
+		}
+		'<character like predicate part 2: 1>' {
+			return [EarleyValue(parse_like(children[1] as Expr) ?)]
+		}
+		'<character like predicate part 2: 2>' {
+			return [EarleyValue(parse_not_like(children[2] as Expr) ?)]
+		}
+		'<character like predicate: 1>' {
+			return [
+				EarleyValue(parse_like_pred(children[0] as Expr, children[1] as LikeExpr) ?),
+			]
 		}
 		'<character position expression: 1>' {
 			return [

--- a/vsql/parse.v
+++ b/vsql/parse.v
@@ -514,3 +514,15 @@ fn parse_row_constructor1(exprs []Expr) ?Expr {
 fn parse_row_constructor2(expr QueryExpression) ?Expr {
 	return expr
 }
+
+fn parse_like_pred(left Expr, like LikeExpr) ?Expr {
+	return LikeExpr{left, like.right, like.not}
+}
+
+fn parse_like(expr Expr) ?LikeExpr {
+	return LikeExpr{NoExpr{}, expr, false}
+}
+
+fn parse_not_like(expr Expr) ?LikeExpr {
+	return LikeExpr{NoExpr{}, expr, true}
+}


### PR DESCRIPTION
    X [ NOT ] LIKE Y

Tests if X matches the like-expression of Y. Apart from simple regexp
matching, this is very useful for testing the prefix or suffix of a
string.

Matching is always against the entire string (not a partial match) and
is case-sensitive. You can use the following characters in Y:

- "_" matches any single character.
- "%" matches zero, one or more characters.

Examples:

    'a' LIKE 'a'          -- TRUE
    'a' LIKE 'A'          -- FALSE
    'ab' LIKE 'a_'        -- TRUE
    'abc' LIKE 'a_'       -- FALSE
    'acdeb' LIKE 'a%b'    -- TRUE
    'abc' NOT LIKE 'a%'   -- FALSE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/80)
<!-- Reviewable:end -->
