### PR TITLE
Adding SIMILAR TO expression

### DIFF
--- a/docs/expressions.rst
+++ b/docs/expressions.rst
@@ -50,8 +50,16 @@ matching, this is very useful for testing the prefix or suffix of a string.
 Matching is always against the entire string (not a partial match) and is
 case-sensitive. You can use the following characters in ``Y``:
 
-- ``_`` matches any single character.
-- ``%`` matches zero, one or more characters.
+.. list-table::
+   :header-rows: 1
+
+   * - Operator
+     - Description
+
+   * - ``%``
+     - Matches any sequence of zero or more characters.
+   * - ``_``
+     - Matches any single character.
 
 *Examples*
 
@@ -63,3 +71,60 @@ case-sensitive. You can use the following characters in ``Y``:
   'abc' LIKE 'a_'       -- FALSE
   'acdeb' LIKE 'a%b'    -- TRUE
   'abc' NOT LIKE 'a%'   -- FALSE
+
+SIMILAR TO
+----------
+
+.. code-block:: text
+
+  X [ NOT ] SIMILAR TO Y
+
+Tests if ``X`` matches the similar-expression of ``Y``. The pattern for ``Y`` is
+a superset of the pattern for ``LIKE`` expressions that makes patterns closer to
+regular expressions.
+
+Matching is always against the entire string (not a partial match) and is
+case-sensitive. You can use the following characters in ``Y``:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Operator
+     - Description
+
+   * - ``%``
+     - Matches any sequence of zero or more characters.
+   * - ``_``
+     - Matches any single character.
+   * - ``|``
+     - Denotes alternation (either of two alternatives).
+   * - ``*``
+     - Repeat the previous item zero or more times.
+   * - ``+``
+     - Repeat the previous item one or more times.
+   * - ``?``
+     - Repeat the previous item zero or one time.
+   * - ``{m}``
+     - Repeat the previous item exactly m times.
+   * - ``{m,}``
+     - Repeat the previous item m or more times.
+   * - ``{m,n}``
+     - Repeat the previous item at least m and not more than n times.
+   * - ``()``
+     - Parentheses group items into a single logical item.
+   * - ``[...]``
+     - A bracket expression specifies a character class, just as in POSIX
+       regular expressions.
+
+*Examples*
+
+.. code-block:: sql
+
+  'abc' SIMILAR TO 'abc'                                           -- TRUE
+  'abc' SIMILAR TO '_b_'                                           -- TRUE
+  'abc' SIMILAR TO '_A_'                                           -- FALSE
+  'abc' SIMILAR TO '%(b|d)%'                                       -- TRUE
+  'abc' SIMILAR TO '(b|c)%'                                        -- FALSE
+  'AbcAbcdefgefg12efgefg12' SIMILAR TO '((Ab)?c)+d((efg)+(12))+'   -- TRUE
+  'aaaaaab11111xy' SIMILAR TO 'a{6}_[0-9]{5}(x|y){2}'              -- TRUE
+  '$0.87' SIMILAR TO '$[0-9]+(.[0-9][0-9])?'                       -- TRUE

--- a/grammar.bnf
+++ b/grammar.bnf
@@ -275,6 +275,7 @@
     <comparison predicate>
   | <between predicate>
   | <like predicate>
+  | <similar predicate>
   | <null predicate>
 
 <comparison predicate> /* Expr */ ::=
@@ -790,3 +791,13 @@
 
 <like predicate> /* Expr */ ::=
     <character like predicate>
+
+<similar predicate part 2> /* SimilarExpr */ ::=
+    SIMILAR TO <similar pattern>       -> similar
+  | NOT SIMILAR TO <similar pattern>   -> not_similar
+
+<similar pattern> /* Expr */ ::=
+    <character value expression>
+
+<similar predicate> /* Expr */ ::=
+    <row value predicand> <similar predicate part 2>   -> similar_pred

--- a/tests/like.sql
+++ b/tests/like.sql
@@ -54,3 +54,27 @@ VALUES 'acb' NOT LIKE 'a%b';
 
 VALUES 'acdeb' NOT LIKE 'a%b';
 -- COL1: FALSE
+
+VALUES 'abd' LIKE 'a(b|c)d';
+-- COL1: FALSE
+
+VALUES 'abb' LIKE 'ab*';
+-- COL1: FALSE
+
+VALUES 'abb' LIKE 'ab+';
+-- COL1: FALSE
+
+VALUES 'abb' LIKE 'ab{2}';
+-- COL1: FALSE
+
+VALUES 'abc' LIKE '%(b|d)%';
+-- COL1: FALSE
+
+VALUES 'AbcAbcdefgefg12efgefg12' LIKE '((Ab)?c)+d((efg)+(12))+';
+-- COL1: FALSE
+
+VALUES 'aaaaaab11111xy' LIKE 'a{6}_[0-9]{5}(x|y){2}';
+-- COL1: FALSE
+
+VALUES '$0.87' LIKE '$[0-9]+(.[0-9][0-9])?';
+-- COL1: FALSE

--- a/tests/similar.sql
+++ b/tests/similar.sql
@@ -1,0 +1,95 @@
+EXPLAIN VALUES 'a' SIMILAR TO 'a';
+-- EXPLAIN: VALUES (COL1 BOOLEAN) = ROW('a' SIMILAR TO 'a')
+
+VALUES 'a' SIMILAR TO 'a';
+-- COL1: TRUE
+
+VALUES 'a' SIMILAR TO 'A';
+-- COL1: FALSE
+
+VALUES 'a' SIMILAR TO 'aa';
+-- COL1: FALSE
+
+VALUES 'ab' SIMILAR TO 'a_';
+-- COL1: TRUE
+
+VALUES 'ab' NOT SIMILAR TO 'a_';
+-- COL1: FALSE
+
+VALUES 'abc' SIMILAR TO 'a_';
+-- COL1: FALSE
+
+VALUES 'abc' SIMILAR TO '_b_';
+-- COL1: TRUE
+
+VALUES 'abc' SIMILAR TO '%';
+-- COL1: TRUE
+
+VALUES 'abc' SIMILAR TO 'a%';
+-- COL1: TRUE
+
+VALUES 'abc' NOT SIMILAR TO 'a%';
+-- COL1: FALSE
+
+VALUES 'a' SIMILAR TO 'a%';
+-- COL1: TRUE
+
+VALUES 'ba' SIMILAR TO 'a%';
+-- COL1: FALSE
+
+VALUES 'ab' SIMILAR TO 'a%b';
+-- COL1: TRUE
+
+VALUES 'acb' SIMILAR TO 'a%b';
+-- COL1: TRUE
+
+VALUES 'acdeb' SIMILAR TO 'a%b';
+-- COL1: TRUE
+
+VALUES 'ab' NOT SIMILAR TO 'a%b';
+-- COL1: FALSE
+
+VALUES 'acb' NOT SIMILAR TO 'a%b';
+-- COL1: FALSE
+
+VALUES 'acdeb' NOT SIMILAR TO 'a%b';
+-- COL1: FALSE
+
+VALUES 'abd' SIMILAR TO 'a(b|c)d';
+-- COL1: TRUE
+
+VALUES 'abb' SIMILAR TO 'ab*';
+-- COL1: TRUE
+
+VALUES 'abb' SIMILAR TO 'ab+';
+-- COL1: TRUE
+
+VALUES 'abb' SIMILAR TO 'ab{2}';
+-- COL1: TRUE
+
+VALUES 'abc' SIMILAR TO 'abc';
+-- COL1: TRUE
+
+VALUES 'abc' SIMILAR TO '_b_';
+-- COL1: TRUE
+
+VALUES 'abc' SIMILAR TO '_A_';
+-- COL1: FALSE
+
+VALUES 'abc' SIMILAR TO '%(b|d)%';
+-- COL1: TRUE
+
+VALUES 'abc' SIMILAR TO '(b|c)%';
+-- COL1: FALSE
+
+VALUES 'AbcAbcdefgefg12efgefg12' SIMILAR TO '((Ab)?c)+d((efg)+(12))+';
+-- COL1: TRUE
+
+VALUES 'aaaaaab11111xy' SIMILAR TO 'a{6}_[0-9]{5}(x|y){2}';
+-- COL1: TRUE
+
+VALUES '$0.87' SIMILAR TO '$[0-9]+(.[0-9][0-9])?';
+-- COL1: TRUE
+
+VALUES 'abc' SIMILAR TO 'a.c';
+-- COL1: FALSE

--- a/vsql/ast.v
+++ b/vsql/ast.v
@@ -26,6 +26,7 @@ type Expr = BetweenExpr
 	| Parameter
 	| QueryExpression
 	| RowExpr
+	| SimilarExpr
 	| UnaryExpr
 	| Value
 
@@ -63,6 +64,9 @@ fn (e Expr) pstr(params map[string]Value) string {
 			e.pstr(params)
 		}
 		RowExpr {
+			e.pstr(params)
+		}
+		SimilarExpr {
 			e.pstr(params)
 		}
 		UnaryExpr {
@@ -384,4 +388,19 @@ fn (e LikeExpr) pstr(params map[string]Value) string {
 	}
 
 	return '${e.left.pstr(params)} LIKE ${e.right.pstr(params)}'
+}
+
+// SimilarExpr for "SIMILAR TO" and "NOT SIMILAR TO".
+struct SimilarExpr {
+	left  Expr
+	right Expr
+	not   bool
+}
+
+fn (e SimilarExpr) pstr(params map[string]Value) string {
+	if e.not {
+		return '${e.left.pstr(params)} NOT SIMILAR TO ${e.right.pstr(params)}'
+	}
+
+	return '${e.left.pstr(params)} SIMILAR TO ${e.right.pstr(params)}'
 }

--- a/vsql/grammar.v
+++ b/vsql/grammar.v
@@ -15,6 +15,7 @@ type EarleyValue = BetweenExpr
 	| LikeExpr
 	| QueryExpression
 	| SelectList
+	| SimilarExpr
 	| SimpleTable
 	| Stmt
 	| TableElement
@@ -870,6 +871,24 @@ fn get_grammar() map[string]EarleyRule {
 	mut rule_signed_numeric_literal_ := &EarleyRule{
 		name: '<signed numeric literal>'
 	}
+	mut rule_similar_pattern_ := &EarleyRule{
+		name: '<similar pattern>'
+	}
+	mut rule_similar_predicate_part_2_1_ := &EarleyRule{
+		name: '<similar predicate part 2: 1>'
+	}
+	mut rule_similar_predicate_part_2_2_ := &EarleyRule{
+		name: '<similar predicate part 2: 2>'
+	}
+	mut rule_similar_predicate_part_2_ := &EarleyRule{
+		name: '<similar predicate part 2>'
+	}
+	mut rule_similar_predicate_1_ := &EarleyRule{
+		name: '<similar predicate: 1>'
+	}
+	mut rule_similar_predicate_ := &EarleyRule{
+		name: '<similar predicate>'
+	}
 	mut rule_simple_table_ := &EarleyRule{
 		name: '<simple table>'
 	}
@@ -1266,6 +1285,9 @@ fn get_grammar() map[string]EarleyRule {
 	mut rule_set := &EarleyRule{
 		name: 'SET'
 	}
+	mut rule_similar := &EarleyRule{
+		name: 'SIMILAR'
+	}
 	mut rule_sin := &EarleyRule{
 		name: 'SIN'
 	}
@@ -1292,6 +1314,9 @@ fn get_grammar() map[string]EarleyRule {
 	}
 	mut rule_tanh := &EarleyRule{
 		name: 'TANH'
+	}
+	mut rule_to := &EarleyRule{
+		name: 'TO'
 	}
 	mut rule_transaction := &EarleyRule{
 		name: 'TRANSACTION'
@@ -3550,6 +3575,11 @@ fn get_grammar() map[string]EarleyRule {
 	]}
 	rule_predicate_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
+			rule: rule_similar_predicate_
+		},
+	]}
+	rule_predicate_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
 			rule: rule_null_predicate_
 		},
 	]}
@@ -4027,6 +4057,65 @@ fn get_grammar() map[string]EarleyRule {
 	rule_signed_numeric_literal_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_signed_numeric_literal_2_
+		},
+	]}
+
+	rule_similar_pattern_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_character_value_expression_
+		},
+	]}
+
+	rule_similar_predicate_part_2_1_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_similar
+		},
+		&EarleyRuleOrString{
+			rule: rule_to
+		},
+		&EarleyRuleOrString{
+			rule: rule_similar_pattern_
+		},
+	]}
+
+	rule_similar_predicate_part_2_2_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_not
+		},
+		&EarleyRuleOrString{
+			rule: rule_similar
+		},
+		&EarleyRuleOrString{
+			rule: rule_to
+		},
+		&EarleyRuleOrString{
+			rule: rule_similar_pattern_
+		},
+	]}
+
+	rule_similar_predicate_part_2_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_similar_predicate_part_2_1_
+		},
+	]}
+	rule_similar_predicate_part_2_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_similar_predicate_part_2_2_
+		},
+	]}
+
+	rule_similar_predicate_1_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_row_value_predicand_
+		},
+		&EarleyRuleOrString{
+			rule: rule_similar_predicate_part_2_
+		},
+	]}
+
+	rule_similar_predicate_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_similar_predicate_1_
 		},
 	]}
 
@@ -5152,6 +5241,13 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
+	rule_similar.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			str: 'SIMILAR'
+			rule: 0
+		},
+	]}
+
 	rule_sin.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			str: 'SIN'
@@ -5211,6 +5307,13 @@ fn get_grammar() map[string]EarleyRule {
 	rule_tanh.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			str: 'TANH'
+			rule: 0
+		},
+	]}
+
+	rule_to.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			str: 'TO'
 			rule: 0
 		},
 	]}
@@ -5557,6 +5660,12 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<signed numeric literal: 1>'] = rule_signed_numeric_literal_1_
 	rules['<signed numeric literal: 2>'] = rule_signed_numeric_literal_2_
 	rules['<signed numeric literal>'] = rule_signed_numeric_literal_
+	rules['<similar pattern>'] = rule_similar_pattern_
+	rules['<similar predicate part 2: 1>'] = rule_similar_predicate_part_2_1_
+	rules['<similar predicate part 2: 2>'] = rule_similar_predicate_part_2_2_
+	rules['<similar predicate part 2>'] = rule_similar_predicate_part_2_
+	rules['<similar predicate: 1>'] = rule_similar_predicate_1_
+	rules['<similar predicate>'] = rule_similar_predicate_
 	rules['<simple table>'] = rule_simple_table_
 	rules['<simple value specification>'] = rule_simple_value_specification_
 	rules['<solidus>'] = rule_solidus_
@@ -5689,6 +5798,7 @@ fn get_grammar() map[string]EarleyRule {
 	rules['ROWS'] = rule_rows
 	rules['SELECT'] = rule_select
 	rules['SET'] = rule_set
+	rules['SIMILAR'] = rule_similar
 	rules['SIN'] = rule_sin
 	rules['SINH'] = rule_sinh
 	rules['SMALLINT'] = rule_smallint
@@ -5698,6 +5808,7 @@ fn get_grammar() map[string]EarleyRule {
 	rules['TABLE'] = rule_table
 	rules['TAN'] = rule_tan
 	rules['TANH'] = rule_tanh
+	rules['TO'] = rule_to
 	rules['TRANSACTION'] = rule_transaction
 	rules['TRUE'] = rule_true
 	rules['UNKNOWN'] = rule_unknown
@@ -6199,6 +6310,17 @@ fn parse_ast_name(children []EarleyValue, name string) ?[]EarleyValue {
 		'<signed numeric literal: 2>' {
 			return [
 				EarleyValue(parse_sign_expr(children[0] as string, children[1] as Value) ?),
+			]
+		}
+		'<similar predicate part 2: 1>' {
+			return [EarleyValue(parse_similar(children[2] as Expr) ?)]
+		}
+		'<similar predicate part 2: 2>' {
+			return [EarleyValue(parse_not_similar(children[3] as Expr) ?)]
+		}
+		'<similar predicate: 1>' {
+			return [
+				EarleyValue(parse_similar_pred(children[0] as Expr, children[1] as SimilarExpr) ?),
 			]
 		}
 		'<SQL argument list: 1>' {

--- a/vsql/parse.v
+++ b/vsql/parse.v
@@ -526,3 +526,15 @@ fn parse_like(expr Expr) ?LikeExpr {
 fn parse_not_like(expr Expr) ?LikeExpr {
 	return LikeExpr{NoExpr{}, expr, true}
 }
+
+fn parse_similar_pred(left Expr, like SimilarExpr) ?Expr {
+	return SimilarExpr{left, like.right, like.not}
+}
+
+fn parse_similar(expr Expr) ?SimilarExpr {
+	return SimilarExpr{NoExpr{}, expr, false}
+}
+
+fn parse_not_similar(expr Expr) ?SimilarExpr {
+	return SimilarExpr{NoExpr{}, expr, true}
+}


### PR DESCRIPTION
    X [ NOT ] SIMILAR TO Y

Tests if X matches the similar-expression of Y. The pattern for Y is a
superset of the pattern for LIKE expressions that makes patterns closer
to regular expressions.

Matching is always against the entire string (not a partial match) and is
case-sensitive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/82)
<!-- Reviewable:end -->
