### PR TITLE
Add ORDER BY clause

### DIFF
--- a/docs/select.rst
+++ b/docs/select.rst
@@ -13,6 +13,7 @@ Syntax
   SELECT <expression> [ AS <name> ] , ...
   FROM <table_name>
   [ WHERE <condition> ]
+  [ ORDER BY <expr> [ ASC | DESC ], ... ]
   [ OFFSET <integer> { ROW | ROWS } ]
   [ FETCH FIRST <integer> { ROW | ROWS } ONLY ]
 
@@ -29,6 +30,25 @@ WHERE
 -----
 
 If ``WHERE`` is not provided all rows are returned.
+
+ORDER BY
+--------
+
+The ``ORDER BY`` clause can be used to sort records.
+
+Without an ``ORDER BY`` clause the rows might come out in a predictable order,
+such as the order or insertion or the order of the PRIMARY KEY. However, you
+should never depend on this since it's subject to change either through
+deliberate or emergent behavior. If you need the rows to be returned in a
+specific order you should always specify an appropriate ``ORDER BY`` clause.
+
+The ``ORDER BY`` contains one or more expressions. Each specifying an ``ASC`` or
+``DESC`` for ascending or descending respectively. If no qualifier is specified
+then ``ASC`` is used.
+
+The SQL standard doesn't define if ``NULL`` should be always be ordered first or
+last. In vsql, ``NULL`` is always considered to be less than any other non
+``NULL`` value.
 
 OFFSET
 ------
@@ -65,3 +85,5 @@ Examples
 
   SELECT price * (1 + tax) AS total
   FROM products;
+
+  SELECT * FROM products ORDER BY price;

--- a/grammar.bnf
+++ b/grammar.bnf
@@ -404,14 +404,22 @@
     <query expression>   -> cursor_specification
 
 <query expression> /* QueryExpression */ ::=
-    <query expression body>   -> query_expression
+    <query expression body>                     -> query_expression
+  | <query expression body> <order by clause>   -> query_expression_order
   | <query expression body>
-    <result offset clause>    -> query_expression_offset
+    <result offset clause>                      -> query_expression_offset
+  | <query expression body> <order by clause>
+    <result offset clause>                      -> query_expression_order_offset
   | <query expression body>
-    <fetch first clause>      -> query_expression_fetch
+    <fetch first clause>                        -> query_expression_fetch
+  | <query expression body> <order by clause>
+    <fetch first clause>                        -> query_expression_order_fetch
+  | <query expression body> <order by clause>
+    <result offset clause>
+    <fetch first clause>                        -> query_expression_order_offset_fetch
   | <query expression body>
     <result offset clause>
-    <fetch first clause>      -> query_expression_offset_fetch
+    <fetch first clause>                        -> query_expression_offset_fetch
 
 <query expression body> /* SimpleTable */ ::=
     <query term>
@@ -801,3 +809,21 @@
 
 <similar predicate> /* Expr */ ::=
     <row value predicand> <similar predicate part 2>   -> similar_pred
+
+<order by clause> /* []SortSpecification */ ::=
+    ORDER BY <sort specification list>   -> order_by
+
+<sort specification list> /* []SortSpecification */ ::=
+    <sort specification>                                     -> sort_list1
+  | <sort specification list> <comma> <sort specification>   -> sort_list2
+
+<sort specification> /* SortSpecification */ ::=
+    <sort key>                            -> sort1
+  | <sort key> <ordering specification>   -> sort2
+
+<sort key> /* Expr */ ::=
+    <value expression>
+
+<ordering specification> /* bool */ ::=
+    ASC    -> yes
+  | DESC   -> no

--- a/tests/order-nulls.sql
+++ b/tests/order-nulls.sql
@@ -1,0 +1,18 @@
+/* setup */
+CREATE TABLE bar (x FLOAT);
+INSERT INTO bar (x) VALUES (4.567);
+INSERT INTO bar (x) VALUES (NULL);
+INSERT INTO bar (x) VALUES (1.234);
+INSERT INTO bar (x) VALUES (NULL);
+
+SELECT * FROM bar ORDER BY x;
+-- X: NULL
+-- X: NULL
+-- X: 1.234
+-- X: 4.567
+
+SELECT * FROM bar ORDER BY x DESC;
+-- X: 4.567
+-- X: 1.234
+-- X: NULL
+-- X: NULL

--- a/tests/order.sql
+++ b/tests/order.sql
@@ -1,0 +1,134 @@
+/* setup */
+CREATE TABLE foo (x FLOAT, y VARCHAR(32));
+INSERT INTO foo (x, y) VALUES (1.234, 'hi');
+INSERT INTO foo (x, y) VALUES (12.34, 'there');
+INSERT INTO foo (x, y) VALUES (0.1234, 'hi');
+INSERT INTO foo (x, y) VALUES (5.6, 'bar');
+
+EXPLAIN SELECT * FROM foo ORDER BY x;
+-- EXPLAIN: TABLE FOO (X DOUBLE PRECISION, Y CHARACTER VARYING(32))
+-- EXPLAIN: ORDER BY X ASC
+
+SELECT * FROM foo ORDER BY x;
+-- X: 0.1234 Y: hi
+-- X: 1.234 Y: hi
+-- X: 5.6 Y: bar
+-- X: 12.34 Y: there
+
+EXPLAIN SELECT * FROM foo ORDER BY x ASC;
+-- EXPLAIN: TABLE FOO (X DOUBLE PRECISION, Y CHARACTER VARYING(32))
+-- EXPLAIN: ORDER BY X ASC
+
+EXPLAIN SELECT * FROM foo ORDER BY x DESC;
+-- EXPLAIN: TABLE FOO (X DOUBLE PRECISION, Y CHARACTER VARYING(32))
+-- EXPLAIN: ORDER BY X DESC
+
+SELECT * FROM foo ORDER BY x DESC;
+-- X: 12.34 Y: there
+-- X: 5.6 Y: bar
+-- X: 1.234 Y: hi
+-- X: 0.1234 Y: hi
+
+SELECT * FROM foo ORDER BY y;
+-- X: 5.6 Y: bar
+-- X: 1.234 Y: hi
+-- X: 0.1234 Y: hi
+-- X: 12.34 Y: there
+
+EXPLAIN SELECT * FROM foo ORDER BY y, x;
+-- EXPLAIN: TABLE FOO (X DOUBLE PRECISION, Y CHARACTER VARYING(32))
+-- EXPLAIN: ORDER BY Y ASC, X ASC
+
+SELECT * FROM foo ORDER BY y, x;
+-- X: 5.6 Y: bar
+-- X: 0.1234 Y: hi
+-- X: 1.234 Y: hi
+-- X: 12.34 Y: there
+
+SELECT * FROM foo ORDER BY y, x DESC;
+-- X: 5.6 Y: bar
+-- X: 1.234 Y: hi
+-- X: 0.1234 Y: hi
+-- X: 12.34 Y: there
+
+SELECT * FROM foo ORDER BY x DESC, y;
+-- X: 12.34 Y: there
+-- X: 5.6 Y: bar
+-- X: 1.234 Y: hi
+-- X: 0.1234 Y: hi
+
+EXPLAIN SELECT * FROM foo ORDER BY ABS(10 - x);
+-- EXPLAIN: TABLE FOO (X DOUBLE PRECISION, Y CHARACTER VARYING(32))
+-- EXPLAIN: ORDER BY ABS(10 - X) ASC
+
+SELECT * FROM foo ORDER BY ABS(10 - x);
+-- X: 12.34 Y: there
+-- X: 5.6 Y: bar
+-- X: 1.234 Y: hi
+-- X: 0.1234 Y: hi
+
+SELECT * FROM foo ORDER BY ABS(10 - x) DESC;
+-- X: 0.1234 Y: hi
+-- X: 1.234 Y: hi
+-- X: 5.6 Y: bar
+-- X: 12.34 Y: there
+
+SELECT * FROM foo
+ORDER BY y, x
+OFFSET 0 ROWS;
+-- X: 5.6 Y: bar
+-- X: 0.1234 Y: hi
+-- X: 1.234 Y: hi
+-- X: 12.34 Y: there
+
+EXPLAIN SELECT * FROM foo
+ORDER BY y, x
+OFFSET 2 ROW;
+-- EXPLAIN: TABLE FOO (X DOUBLE PRECISION, Y CHARACTER VARYING(32))
+-- EXPLAIN: ORDER BY Y ASC, X ASC
+-- EXPLAIN: OFFSET 2 ROWS
+
+SELECT * FROM foo
+ORDER BY y, x
+OFFSET 2 ROW;
+-- X: 1.234 Y: hi
+-- X: 12.34 Y: there
+
+SELECT * FROM foo
+ORDER BY y, x
+OFFSET 50 ROW;
+
+SELECT * FROM foo
+ORDER BY y, x
+FETCH FIRST 2 ROWS ONLY;
+-- X: 5.6 Y: bar
+-- X: 0.1234 Y: hi
+
+EXPLAIN SELECT * FROM foo
+ORDER BY y, x
+OFFSET 1 ROW
+FETCH FIRST 2 ROWS ONLY;
+-- EXPLAIN: TABLE FOO (X DOUBLE PRECISION, Y CHARACTER VARYING(32))
+-- EXPLAIN: ORDER BY Y ASC, X ASC
+-- EXPLAIN: OFFSET 1 ROWS FETCH FIRST 2 ROWS ONLY
+
+SELECT * FROM foo
+ORDER BY y, x
+OFFSET 1 ROW
+FETCH FIRST 2 ROWS ONLY;
+-- X: 0.1234 Y: hi
+-- X: 1.234 Y: hi
+
+SELECT * FROM foo
+ORDER BY y, x
+OFFSET 10 ROWS
+FETCH FIRST 2 ROWS ONLY;
+
+/* set offset_num 1 */
+/* set row_num 2 */
+SELECT * FROM foo
+ORDER BY y, x
+OFFSET :offset_num ROW
+FETCH FIRST :row_num ROWS ONLY;
+-- X: 0.1234 Y: hi
+-- X: 1.234 Y: hi

--- a/vsql/ast.v
+++ b/vsql/ast.v
@@ -356,6 +356,7 @@ struct QueryExpression {
 	body   SimpleTable
 	fetch  Expr
 	offset Expr
+	order  []SortSpecification
 }
 
 fn (e QueryExpression) pstr(params map[string]Value) string {
@@ -403,4 +404,17 @@ fn (e SimilarExpr) pstr(params map[string]Value) string {
 	}
 
 	return '${e.left.pstr(params)} SIMILAR TO ${e.right.pstr(params)}'
+}
+
+struct SortSpecification {
+	expr   Expr
+	is_asc bool
+}
+
+fn (e SortSpecification) pstr(params map[string]Value) string {
+	if e.is_asc {
+		return '${e.expr.pstr(params)} ASC'
+	}
+
+	return '${e.expr.pstr(params)} DESC'
 }

--- a/vsql/grammar.v
+++ b/vsql/grammar.v
@@ -17,6 +17,7 @@ type EarleyValue = BetweenExpr
 	| SelectList
 	| SimilarExpr
 	| SimpleTable
+	| SortSpecification
 	| Stmt
 	| TableElement
 	| TableExpression
@@ -26,6 +27,7 @@ type EarleyValue = BetweenExpr
 	| Value
 	| []Expr
 	| []Identifier
+	| []SortSpecification
 	| []TableElement
 	| bool
 	| map[string]Expr
@@ -673,6 +675,21 @@ fn get_grammar() map[string]EarleyRule {
 	mut rule_offset_row_count_ := &EarleyRule{
 		name: '<offset row count>'
 	}
+	mut rule_order_by_clause_1_ := &EarleyRule{
+		name: '<order by clause: 1>'
+	}
+	mut rule_order_by_clause_ := &EarleyRule{
+		name: '<order by clause>'
+	}
+	mut rule_ordering_specification_1_ := &EarleyRule{
+		name: '<ordering specification: 1>'
+	}
+	mut rule_ordering_specification_2_ := &EarleyRule{
+		name: '<ordering specification: 2>'
+	}
+	mut rule_ordering_specification_ := &EarleyRule{
+		name: '<ordering specification>'
+	}
 	mut rule_parenthesized_boolean_value_expression_1_ := &EarleyRule{
 		name: '<parenthesized boolean value expression: 1>'
 	}
@@ -744,6 +761,18 @@ fn get_grammar() map[string]EarleyRule {
 	}
 	mut rule_query_expression_4_ := &EarleyRule{
 		name: '<query expression: 4>'
+	}
+	mut rule_query_expression_5_ := &EarleyRule{
+		name: '<query expression: 5>'
+	}
+	mut rule_query_expression_6_ := &EarleyRule{
+		name: '<query expression: 6>'
+	}
+	mut rule_query_expression_7_ := &EarleyRule{
+		name: '<query expression: 7>'
+	}
+	mut rule_query_expression_8_ := &EarleyRule{
+		name: '<query expression: 8>'
 	}
 	mut rule_query_expression_ := &EarleyRule{
 		name: '<query expression>'
@@ -897,6 +926,27 @@ fn get_grammar() map[string]EarleyRule {
 	}
 	mut rule_solidus_ := &EarleyRule{
 		name: '<solidus>'
+	}
+	mut rule_sort_key_ := &EarleyRule{
+		name: '<sort key>'
+	}
+	mut rule_sort_specification_list_1_ := &EarleyRule{
+		name: '<sort specification list: 1>'
+	}
+	mut rule_sort_specification_list_2_ := &EarleyRule{
+		name: '<sort specification list: 2>'
+	}
+	mut rule_sort_specification_list_ := &EarleyRule{
+		name: '<sort specification list>'
+	}
+	mut rule_sort_specification_1_ := &EarleyRule{
+		name: '<sort specification: 1>'
+	}
+	mut rule_sort_specification_2_ := &EarleyRule{
+		name: '<sort specification: 2>'
+	}
+	mut rule_sort_specification_ := &EarleyRule{
+		name: '<sort specification>'
 	}
 	mut rule_sql_argument_list_1_ := &EarleyRule{
 		name: '<SQL argument list: 1>'
@@ -1126,6 +1176,9 @@ fn get_grammar() map[string]EarleyRule {
 	mut rule_as := &EarleyRule{
 		name: 'AS'
 	}
+	mut rule_asc := &EarleyRule{
+		name: 'ASC'
+	}
 	mut rule_asin := &EarleyRule{
 		name: 'ASIN'
 	}
@@ -1143,6 +1196,9 @@ fn get_grammar() map[string]EarleyRule {
 	}
 	mut rule_boolean := &EarleyRule{
 		name: 'BOOLEAN'
+	}
+	mut rule_by := &EarleyRule{
+		name: 'BY'
 	}
 	mut rule_ceil := &EarleyRule{
 		name: 'CEIL'
@@ -1176,6 +1232,9 @@ fn get_grammar() map[string]EarleyRule {
 	}
 	mut rule_delete := &EarleyRule{
 		name: 'DELETE'
+	}
+	mut rule_desc := &EarleyRule{
+		name: 'DESC'
 	}
 	mut rule_double := &EarleyRule{
 		name: 'DOUBLE'
@@ -1254,6 +1313,9 @@ fn get_grammar() map[string]EarleyRule {
 	}
 	mut rule_or := &EarleyRule{
 		name: 'OR'
+	}
+	mut rule_order := &EarleyRule{
+		name: 'ORDER'
 	}
 	mut rule_position := &EarleyRule{
 		name: 'POSITION'
@@ -3435,6 +3497,47 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
+	rule_order_by_clause_1_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_order
+		},
+		&EarleyRuleOrString{
+			rule: rule_by
+		},
+		&EarleyRuleOrString{
+			rule: rule_sort_specification_list_
+		},
+	]}
+
+	rule_order_by_clause_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_order_by_clause_1_
+		},
+	]}
+
+	rule_ordering_specification_1_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_asc
+		},
+	]}
+
+	rule_ordering_specification_2_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_desc
+		},
+	]}
+
+	rule_ordering_specification_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_ordering_specification_1_
+		},
+	]}
+	rule_ordering_specification_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_ordering_specification_2_
+		},
+	]}
+
 	rule_parenthesized_boolean_value_expression_1_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_left_paren_
@@ -3656,7 +3759,7 @@ fn get_grammar() map[string]EarleyRule {
 			rule: rule_query_expression_body_
 		},
 		&EarleyRuleOrString{
-			rule: rule_result_offset_clause_
+			rule: rule_order_by_clause_
 		},
 	]}
 
@@ -3665,11 +3768,59 @@ fn get_grammar() map[string]EarleyRule {
 			rule: rule_query_expression_body_
 		},
 		&EarleyRuleOrString{
-			rule: rule_fetch_first_clause_
+			rule: rule_result_offset_clause_
 		},
 	]}
 
 	rule_query_expression_4_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_query_expression_body_
+		},
+		&EarleyRuleOrString{
+			rule: rule_order_by_clause_
+		},
+		&EarleyRuleOrString{
+			rule: rule_result_offset_clause_
+		},
+	]}
+
+	rule_query_expression_5_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_query_expression_body_
+		},
+		&EarleyRuleOrString{
+			rule: rule_fetch_first_clause_
+		},
+	]}
+
+	rule_query_expression_6_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_query_expression_body_
+		},
+		&EarleyRuleOrString{
+			rule: rule_order_by_clause_
+		},
+		&EarleyRuleOrString{
+			rule: rule_fetch_first_clause_
+		},
+	]}
+
+	rule_query_expression_7_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_query_expression_body_
+		},
+		&EarleyRuleOrString{
+			rule: rule_order_by_clause_
+		},
+		&EarleyRuleOrString{
+			rule: rule_result_offset_clause_
+		},
+		&EarleyRuleOrString{
+			rule: rule_fetch_first_clause_
+		},
+	]}
+
+	rule_query_expression_8_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_query_expression_body_
 		},
@@ -3699,6 +3850,26 @@ fn get_grammar() map[string]EarleyRule {
 	rule_query_expression_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_query_expression_4_
+		},
+	]}
+	rule_query_expression_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_query_expression_5_
+		},
+	]}
+	rule_query_expression_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_query_expression_6_
+		},
+	]}
+	rule_query_expression_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_query_expression_7_
+		},
+	]}
+	rule_query_expression_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_query_expression_8_
 		},
 	]}
 
@@ -4145,6 +4316,67 @@ fn get_grammar() map[string]EarleyRule {
 		&EarleyRuleOrString{
 			str: '/'
 			rule: 0
+		},
+	]}
+
+	rule_sort_key_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_value_expression_
+		},
+	]}
+
+	rule_sort_specification_list_1_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_sort_specification_
+		},
+	]}
+
+	rule_sort_specification_list_2_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_sort_specification_list_
+		},
+		&EarleyRuleOrString{
+			rule: rule_comma_
+		},
+		&EarleyRuleOrString{
+			rule: rule_sort_specification_
+		},
+	]}
+
+	rule_sort_specification_list_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_sort_specification_list_1_
+		},
+	]}
+	rule_sort_specification_list_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_sort_specification_list_2_
+		},
+	]}
+
+	rule_sort_specification_1_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_sort_key_
+		},
+	]}
+
+	rule_sort_specification_2_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_sort_key_
+		},
+		&EarleyRuleOrString{
+			rule: rule_ordering_specification_
+		},
+	]}
+
+	rule_sort_specification_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_sort_specification_1_
+		},
+	]}
+	rule_sort_specification_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_sort_specification_2_
 		},
 	]}
 
@@ -4870,6 +5102,13 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
+	rule_asc.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			str: 'ASC'
+			rule: 0
+		},
+	]}
+
 	rule_asin.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			str: 'ASIN'
@@ -4908,6 +5147,13 @@ fn get_grammar() map[string]EarleyRule {
 	rule_boolean.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			str: 'BOOLEAN'
+			rule: 0
+		},
+	]}
+
+	rule_by.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			str: 'BY'
 			rule: 0
 		},
 	]}
@@ -4985,6 +5231,13 @@ fn get_grammar() map[string]EarleyRule {
 	rule_delete.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			str: 'DELETE'
+			rule: 0
+		},
+	]}
+
+	rule_desc.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			str: 'DESC'
 			rule: 0
 		},
 	]}
@@ -5167,6 +5420,13 @@ fn get_grammar() map[string]EarleyRule {
 	rule_or.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			str: 'OR'
+			rule: 0
+		},
+	]}
+
+	rule_order.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			str: 'ORDER'
 			rule: 0
 		},
 	]}
@@ -5594,6 +5854,11 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<octet length expression: 1>'] = rule_octet_length_expression_1_
 	rules['<octet length expression>'] = rule_octet_length_expression_
 	rules['<offset row count>'] = rule_offset_row_count_
+	rules['<order by clause: 1>'] = rule_order_by_clause_1_
+	rules['<order by clause>'] = rule_order_by_clause_
+	rules['<ordering specification: 1>'] = rule_ordering_specification_1_
+	rules['<ordering specification: 2>'] = rule_ordering_specification_2_
+	rules['<ordering specification>'] = rule_ordering_specification_
 	rules['<parenthesized boolean value expression: 1>'] = rule_parenthesized_boolean_value_expression_1_
 	rules['<parenthesized boolean value expression>'] = rule_parenthesized_boolean_value_expression_
 	rules['<parenthesized derived column list: 1>'] = rule_parenthesized_derived_column_list_1_
@@ -5618,6 +5883,10 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<query expression: 2>'] = rule_query_expression_2_
 	rules['<query expression: 3>'] = rule_query_expression_3_
 	rules['<query expression: 4>'] = rule_query_expression_4_
+	rules['<query expression: 5>'] = rule_query_expression_5_
+	rules['<query expression: 6>'] = rule_query_expression_6_
+	rules['<query expression: 7>'] = rule_query_expression_7_
+	rules['<query expression: 8>'] = rule_query_expression_8_
 	rules['<query expression>'] = rule_query_expression_
 	rules['<query primary>'] = rule_query_primary_
 	rules['<query specification: 1>'] = rule_query_specification_1_
@@ -5669,6 +5938,13 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<simple table>'] = rule_simple_table_
 	rules['<simple value specification>'] = rule_simple_value_specification_
 	rules['<solidus>'] = rule_solidus_
+	rules['<sort key>'] = rule_sort_key_
+	rules['<sort specification list: 1>'] = rule_sort_specification_list_1_
+	rules['<sort specification list: 2>'] = rule_sort_specification_list_2_
+	rules['<sort specification list>'] = rule_sort_specification_list_
+	rules['<sort specification: 1>'] = rule_sort_specification_1_
+	rules['<sort specification: 2>'] = rule_sort_specification_2_
+	rules['<sort specification>'] = rule_sort_specification_
 	rules['<SQL argument list: 1>'] = rule_sql_argument_list_1_
 	rules['<SQL argument list: 2>'] = rule_sql_argument_list_2_
 	rules['<SQL argument list: 3>'] = rule_sql_argument_list_3_
@@ -5745,12 +6021,14 @@ fn get_grammar() map[string]EarleyRule {
 	rules['ACOS'] = rule_acos
 	rules['AND'] = rule_and
 	rules['AS'] = rule_as
+	rules['ASC'] = rule_asc
 	rules['ASIN'] = rule_asin
 	rules['ASYMMETRIC'] = rule_asymmetric
 	rules['ATAN'] = rule_atan
 	rules['BETWEEN'] = rule_between
 	rules['BIGINT'] = rule_bigint
 	rules['BOOLEAN'] = rule_boolean
+	rules['BY'] = rule_by
 	rules['CEIL'] = rule_ceil
 	rules['CEILING'] = rule_ceiling
 	rules['CHAR'] = rule_char
@@ -5762,6 +6040,7 @@ fn get_grammar() map[string]EarleyRule {
 	rules['COSH'] = rule_cosh
 	rules['CREATE'] = rule_create
 	rules['DELETE'] = rule_delete
+	rules['DESC'] = rule_desc
 	rules['DOUBLE'] = rule_double
 	rules['DROP'] = rule_drop
 	rules['EXP'] = rule_exp
@@ -5788,6 +6067,7 @@ fn get_grammar() map[string]EarleyRule {
 	rules['OFFSET'] = rule_offset
 	rules['ONLY'] = rule_only
 	rules['OR'] = rule_or
+	rules['ORDER'] = rule_order
 	rules['POSITION'] = rule_position
 	rules['POWER'] = rule_power
 	rules['PRECISION'] = rule_precision
@@ -6212,6 +6492,15 @@ fn parse_ast_name(children []EarleyValue, name string) ?[]EarleyValue {
 		'<octet length expression: 1>' {
 			return [EarleyValue(parse_octet_length(children[2] as Expr) ?)]
 		}
+		'<order by clause: 1>' {
+			return [EarleyValue(parse_order_by(children[2] as []SortSpecification) ?)]
+		}
+		'<ordering specification: 1>' {
+			return [EarleyValue(parse_yes() ?)]
+		}
+		'<ordering specification: 2>' {
+			return [EarleyValue(parse_no() ?)]
+		}
 		'<parenthesized boolean value expression: 1>' {
 			return [EarleyValue(parse_expr(children[1] as Expr) ?)]
 		}
@@ -6233,16 +6522,39 @@ fn parse_ast_name(children []EarleyValue, name string) ?[]EarleyValue {
 		}
 		'<query expression: 2>' {
 			return [
-				EarleyValue(parse_query_expression_offset(children[0] as SimpleTable,
-					children[1] as Expr) ?),
+				EarleyValue(parse_query_expression_order(children[0] as SimpleTable, children[1] as []SortSpecification) ?),
 			]
 		}
 		'<query expression: 3>' {
 			return [
-				EarleyValue(parse_query_expression_fetch(children[0] as SimpleTable, children[1] as Expr) ?),
+				EarleyValue(parse_query_expression_offset(children[0] as SimpleTable,
+					children[1] as Expr) ?),
 			]
 		}
 		'<query expression: 4>' {
+			return [
+				EarleyValue(parse_query_expression_order_offset(children[0] as SimpleTable,
+					children[1] as []SortSpecification, children[2] as Expr) ?),
+			]
+		}
+		'<query expression: 5>' {
+			return [
+				EarleyValue(parse_query_expression_fetch(children[0] as SimpleTable, children[1] as Expr) ?),
+			]
+		}
+		'<query expression: 6>' {
+			return [
+				EarleyValue(parse_query_expression_order_fetch(children[0] as SimpleTable,
+					children[1] as []SortSpecification, children[2] as Expr) ?),
+			]
+		}
+		'<query expression: 7>' {
+			return [
+				EarleyValue(parse_query_expression_order_offset_fetch(children[0] as SimpleTable,
+					children[1] as []SortSpecification, children[2] as Expr, children[3] as Expr) ?),
+			]
+		}
+		'<query expression: 8>' {
 			return [
 				EarleyValue(parse_query_expression_offset_fetch(children[0] as SimpleTable,
 					children[1] as Expr, children[2] as Expr) ?),
@@ -6321,6 +6633,22 @@ fn parse_ast_name(children []EarleyValue, name string) ?[]EarleyValue {
 		'<similar predicate: 1>' {
 			return [
 				EarleyValue(parse_similar_pred(children[0] as Expr, children[1] as SimilarExpr) ?),
+			]
+		}
+		'<sort specification list: 1>' {
+			return [EarleyValue(parse_sort_list1(children[0] as SortSpecification) ?)]
+		}
+		'<sort specification list: 2>' {
+			return [
+				EarleyValue(parse_sort_list2(children[0] as []SortSpecification, children[2] as SortSpecification) ?),
+			]
+		}
+		'<sort specification: 1>' {
+			return [EarleyValue(parse_sort1(children[0] as Expr) ?)]
+		}
+		'<sort specification: 2>' {
+			return [
+				EarleyValue(parse_sort2(children[0] as Expr, children[1] as bool) ?),
 			]
 		}
 		'<SQL argument list: 1>' {

--- a/vsql/order.v
+++ b/vsql/order.v
@@ -1,0 +1,127 @@
+// order.v contains operations for handing ORDER BY operations.
+
+module vsql
+
+struct OrderOperation {
+	order   []SortSpecification
+	params  map[string]Value
+	conn    &Connection
+	columns Columns
+}
+
+fn new_order_operation(order []SortSpecification, params map[string]Value, conn &Connection, columns Columns) &OrderOperation {
+	return &OrderOperation{order, params, conn, columns}
+}
+
+fn (o &OrderOperation) str() string {
+	mut specs := []string{}
+	for spec in o.order {
+		specs << spec.pstr(o.params)
+	}
+
+	return 'ORDER BY ${specs.join(', ')}'
+}
+
+fn (o &OrderOperation) columns() Columns {
+	// Ordering doesn't change the columns so just pass through from the last
+	// operation.
+	return o.columns
+}
+
+fn (o &OrderOperation) execute(rows []Row) ?[]Row {
+	// TODO(elliotchance): I know this is a horribly inefficient way to handle
+	//  sorting. I did it this way because at the time V didn't allow closures
+	//  on M1 macs (which would be required to pass in a sort function).
+	//  Definitely improve this in the future, especially since sorting of the
+	//  top N rows can usually be done must more efficiently than sorting the
+	//  whole set.
+
+	// This sorting implementation uses a linked list which is very simple but
+	// very expensive at O(n^2).
+
+	mut head := &RowLink(0)
+	for row in rows {
+		// First item is assigned to head.
+		if head == 0 {
+			head = &RowLink{
+				row: row
+			}
+			continue
+		}
+
+		// If the item is less than the head we unshift it. This cannot be
+		// easily done in the next step without us needing to keep the previous
+		// pointer as well.
+		head_cmp := row_cmp(o.conn, o.params, row, head.row, o.order) ?
+		if head_cmp < 0 {
+			head = &RowLink{
+				row: row
+				next: head
+			}
+			continue
+		}
+
+		// Find the place to insert.
+		mut cursor := head
+		mut inserted := false
+		for cursor.next != 0 {
+			cmp := row_cmp(o.conn, o.params, row, cursor.next.row, o.order) ?
+			if cmp < 0 {
+				cursor.next = &RowLink{
+					row: row
+					next: cursor.next
+				}
+				inserted = true
+				break
+			}
+			cursor = cursor.next
+		}
+
+		// Or, add it to the tail.
+		if !inserted {
+			cursor.next = &RowLink{
+				row: row
+			}
+		}
+	}
+
+	return head.rows()
+}
+
+[heap]
+struct RowLink {
+	row Row
+mut:
+	next &RowLink = 0
+}
+
+fn (l &RowLink) rows() []Row {
+	mut rows := []Row{}
+	mut cursor := l
+	for cursor.next != 0 {
+		rows << cursor.row
+		cursor = cursor.next
+	}
+
+	rows << cursor.row
+
+	return rows
+}
+
+fn row_cmp(conn &Connection, params map[string]Value, r1 Row, r2 Row, specs []SortSpecification) ?int {
+	for spec in specs {
+		left := eval_as_value(conn, r1, spec.expr, params) ?
+		right := eval_as_value(conn, r2, spec.expr, params) ?
+
+		cmp, _ := left.cmp(right) ?
+		if cmp != 0 {
+			if !spec.is_asc {
+				return -cmp
+			}
+
+			return cmp
+		}
+	}
+
+	return 0
+}

--- a/vsql/parse.v
+++ b/vsql/parse.v
@@ -355,11 +355,29 @@ fn parse_query_expression(body SimpleTable) ?QueryExpression {
 	}
 }
 
+fn parse_query_expression_order(body SimpleTable, order []SortSpecification) ?QueryExpression {
+	return QueryExpression{
+		body: body
+		offset: NoExpr{}
+		fetch: NoExpr{}
+		order: order
+	}
+}
+
 fn parse_query_expression_offset(body SimpleTable, offset Expr) ?QueryExpression {
 	return QueryExpression{
 		body: body
 		offset: offset
 		fetch: NoExpr{}
+	}
+}
+
+fn parse_query_expression_order_offset(body SimpleTable, order []SortSpecification, offset Expr) ?QueryExpression {
+	return QueryExpression{
+		body: body
+		offset: offset
+		fetch: NoExpr{}
+		order: order
 	}
 }
 
@@ -371,11 +389,29 @@ fn parse_query_expression_fetch(body SimpleTable, fetch Expr) ?QueryExpression {
 	}
 }
 
+fn parse_query_expression_order_fetch(body SimpleTable, order []SortSpecification, fetch Expr) ?QueryExpression {
+	return QueryExpression{
+		body: body
+		offset: NoExpr{}
+		fetch: fetch
+		order: order
+	}
+}
+
 fn parse_query_expression_offset_fetch(body SimpleTable, offset Expr, fetch Expr) ?QueryExpression {
 	return QueryExpression{
 		body: body
 		offset: offset
 		fetch: fetch
+	}
+}
+
+fn parse_query_expression_order_offset_fetch(body SimpleTable, order []SortSpecification, offset Expr, fetch Expr) ?QueryExpression {
+	return QueryExpression{
+		body: body
+		offset: offset
+		fetch: fetch
+		order: order
 	}
 }
 
@@ -525,6 +561,29 @@ fn parse_like(expr Expr) ?LikeExpr {
 
 fn parse_not_like(expr Expr) ?LikeExpr {
 	return LikeExpr{NoExpr{}, expr, true}
+}
+
+fn parse_sort1(expr Expr) ?SortSpecification {
+	return SortSpecification{expr, true}
+}
+
+fn parse_sort2(expr Expr, is_asc bool) ?SortSpecification {
+	return SortSpecification{expr, is_asc}
+}
+
+fn parse_sort_list1(spec SortSpecification) ?[]SortSpecification {
+	return [spec]
+}
+
+fn parse_sort_list2(specs []SortSpecification, spec SortSpecification) ?[]SortSpecification {
+	mut specs2 := specs.clone()
+	specs2 << spec
+
+	return specs2
+}
+
+fn parse_order_by(specs []SortSpecification) ?[]SortSpecification {
+	return specs
 }
 
 fn parse_similar_pred(left Expr, like SimilarExpr) ?Expr {

--- a/vsql/planner.v
+++ b/vsql/planner.v
@@ -175,6 +175,10 @@ fn create_update_plan(stmt UpdateStmt, params map[string]Value, c &Connection) ?
 fn create_query_expression_plan(stmt QueryExpression, params map[string]Value, c &Connection, correlation Correlation) ?Plan {
 	mut plan := create_basic_plan(stmt.body, stmt.offset, params, c, true, correlation) ?
 
+	if stmt.order.len > 0 {
+		plan.operations << new_order_operation(stmt.order, params, c, plan.columns())
+	}
+
 	if stmt.fetch !is NoExpr || stmt.offset !is NoExpr {
 		plan.operations << new_limit_operation(stmt.fetch, stmt.offset, params, c, plan.columns())
 	}

--- a/vsql/value.v
+++ b/vsql/value.v
@@ -114,14 +114,22 @@ fn (v Value) str() string {
 //    0 if v == v2
 //    1 if v > v2
 //
-// For the second argument, true if either (or both) values are NULL. If either
-// values are null the first argument must not be considered as it will always
-// be zero.
+// The SQL standard doesn't define if NULLs should be always ordered first or
+// last. In vsql, NULLs are always considered to be less than any other non-null
+// value. The second return value will be true if either value is NULL.
 //
 // Or an error if the values are different types (cannot be compared).
 fn (v Value) cmp(v2 Value) ?(int, bool) {
-	if v.typ.typ == .is_null || v2.typ.typ == .is_null {
+	if v.typ.typ == .is_null && v2.typ.typ == .is_null {
 		return 0, true
+	}
+
+	if v.typ.typ == .is_null {
+		return -1, true
+	}
+
+	if v2.typ.typ == .is_null {
+		return 1, true
 	}
 
 	// TODO(elliotchance): BOOLEAN shouldn't be compared this way.


### PR DESCRIPTION
The ORDER BY clause can be used to sort records.

Without an ORDER BY clause the rows might come out in a predictable
order, such as the order or insertion or the order of the PRIMARY KEY.
However, you should never depend on this since it's subject to change
either through deliberate or emergent behavior. If you need the rows to
be returned in a specific order you should always specify an appropriate
ORDER BY clause.

The ORDER BY contains one or more expressions. Each specifying an ASC or
DESC for ascending or descending respectively. If no qualifier is
specified then ASC is used.

The SQL standard doesn't define if NULL should be always be ordered
first or last. In vsql, NULL is always considered to be less than any
other non-NULL value.

Examples:

    SELECT * FROM foo ORDER BY ABS(10 - x) DESC;

    SELECT * FROM foo ORDER BY x DESC, y;

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/84)
<!-- Reviewable:end -->
