### PR TITLE
Fix a compliation error when casting []byte to string

### DIFF
--- a/vsql/btree_test.v
+++ b/vsql/btree_test.v
@@ -57,7 +57,7 @@ fn run_btree_test(mut pager Pager, size int) ? {
 
 	mut all := []string{}
 	for object in btree.new_range_iterator('R'.bytes(), 'S'.bytes()) {
-		all << string(object.key)
+		all << object.key.bytestr()
 	}
 
 	assert all.len == objs.len
@@ -131,7 +131,7 @@ fn validate_page(mut p Pager, page_number int) ?([]byte, []byte) {
 			// min and max have already been verified in the subpage, but the
 			// min has to equal what our pointer says.
 			if compare_bytes(smallest, object.key) != 0 {
-				panic('${string(object.key)} in page $page_number points to ${bytes_to_int(object.value)}, but child page has head ${string(smallest)}')
+				panic('${object.key.bytestr()} in page $page_number points to ${bytes_to_int(object.value)}, but child page has head ${smallest.bytestr()}')
 				assert false
 			}
 		}
@@ -160,9 +160,9 @@ fn strkeys(p Page) []string {
 	mut keys := []string{}
 	for object in p.objects() {
 		if object.tid == 0 && object.xid == 0 {
-			keys << string(object.key)
+			keys << object.key.bytestr()
 		} else {
-			keys << object.tid.str() + '/' + object.xid.str() + '-' + string(object.key)
+			keys << object.tid.str() + '/' + object.xid.str() + '-' + object.key.bytestr()
 		}
 	}
 
@@ -172,7 +172,7 @@ fn strkeys(p Page) []string {
 fn strobjects(p Page) []string {
 	mut keys := []string{}
 	for object in p.objects() {
-		keys << '${string(object.key)}:${bytes_to_int(object.value)}'
+		keys << '${object.key.bytestr()}:${bytes_to_int(object.value)}'
 	}
 
 	return keys

--- a/vsql/sqlstate.v
+++ b/vsql/sqlstate.v
@@ -48,7 +48,7 @@ pub fn sqlstate_from_int(code int) string {
 		i++
 	}
 
-	return string(b)
+	return b.bytestr()
 }
 
 // Divide by zero.


### PR DESCRIPTION
While installing `vsql` I ran into several minor compilation issues, likely due to a change in vlang's handling of []byte -> string conversion methods.

I have updated the relevant lines with the recommendation from the compiler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/vsql/87)
<!-- Reviewable:end -->
