### PR TITLE
Fix crash that occurs when running vsql cli without a .vsql file cmd argument

### DIFF
--- a/cmd/vsql.v
+++ b/cmd/vsql.v
@@ -60,6 +60,11 @@ fn main() {
 fn cli_command(cmd cli.Command) ? {
 	print_version()
 
+	if cmd.args.len < 1 {
+		println("USAGE: vsql [OPTIONS] <file>.vsql")
+		return
+	}
+
 	mut db := vsql.open(cmd.args[0])?
 	for {
 		print('vsql> ')


### PR DESCRIPTION
```bash
>> vsql # without passing a .vsql file
  V panic: array.get: index out of range (i == 0, a.len == 0)
  v hash: e031096
  C:/Users/python/AppData/Local/Temp/v_0/vsql.11643790152530797335.tmp.c:14438: at _v_panic: Backtrace
  C:/Users/python/AppData/Local/Temp/v_0/vsql.11643790152530797335.tmp.c:13744: by array_get
  C:/Users/python/AppData/Local/Temp/v_0/vsql.11643790152530797335.tmp.c:49010: by main__cli_command
  C:/Users/python/AppData/Local/Temp/v_0/vsql.11643790152530797335.tmp.c:31511: by cli__Command_handle_cb
  C:/Users/python/AppData/Local/Temp/v_0/vsql.11643790152530797335.tmp.c:31505: by cli__Command_parse_commands
  C:/Users/python/AppData/Local/Temp/v_0/vsql.11643790152530797335.tmp.c:31399: by cli__Command_parse
  C:/Users/python/AppData/Local/Temp/v_0/vsql.11643790152530797335.tmp.c:49005: by main__main
  C:/Users/python/AppData/Local/Temp/v_0/vsql.11643790152530797335.tmp.c:49866: by wmain
  00671df0 : by ???
  00671f53 : by ???
  7ffeb2217034 : by ???
```