### PR TITLE
E021-09: TRIM function

### DIFF
--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -445,6 +445,36 @@ be used.
   VALUES SUBSTRING('Жabڣc' FROM 4 USING OCTETS);
   -- COL1: bڣc
 
+TRIM() CHARACTER VARYING
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+``TRIM`` can be constructed in several forms:
+
+.. code-block:: text
+
+  TRIM(
+    [ [ { LEADING | TRAILING | BOTH } ] [ trim_character ] FROM ]
+    trim_source
+  )
+
+If ``LEADING``, ``TRAILING`` or ``BOTH`` is not provided, ``BOTH`` is used.
+
+If ``trim_character`` is not provided, a space (`' '`) is used.
+
+.. code-block:: sql
+
+  VALUES TRIM('  hello world ');
+  -- COL1: hello world
+
+  VALUES TRIM('a' FROM 'aaababccaa');
+  -- COL1: babcc
+
+  VALUES TRIM(LEADING 'a' FROM 'aaababccaa');
+  -- COL1: babccaa
+
+  VALUES TRIM(TRAILING 'a' FROM 'aaababccaa');
+  -- COL1: aaababcc
+
 ``UPPER(CHARACTER VARYING) CHARACTER VARYING`` 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/sql-compliance.rst
+++ b/docs/sql-compliance.rst
@@ -13,7 +13,7 @@ Mandatory Features
 ------------------
 
 As of the latest version (or at least the version of this documentation)
-**vsql supports 54 of the 164 mandatory features** of the
+**vsql supports 56 of the 164 mandatory features** of the
 `SQL:2016 Standard <https://www.iso.org/standard/63556.html>`_.
 
 .. list-table:: Table 43 — Feature taxonomy and definition for mandatory features
@@ -70,7 +70,7 @@ As of the latest version (or at least the version of this documentation)
    * - ✅ E021-08
      - ``UPPER`` and ``LOWER`` functions
 
-   * - ❌ E021-09
+   * - ✅ E021-09
      - ``TRIM`` function
 
    * - ❌ E021-10

--- a/generate-grammar.py
+++ b/generate-grammar.py
@@ -515,6 +515,7 @@ def parse_tree(text):
 # parse_tree("SELECT x , y FROM ( SELECT x , y FROM t1 )")
 # parse_tree("VALUES TIMESTAMP '2022-06-30'")
 # parse_tree("INSERT INTO foo ( f1 ) VALUES ( TIMESTAMP '2022-06-30' )")
+# parse_tree("VALUES TRIM ( 'helloworld' )")
 
 for arg in sys.argv[1:]:
     print(arg)

--- a/grammar.bnf
+++ b/grammar.bnf
@@ -955,6 +955,28 @@
 <character value function> /* Expr */ ::=
     <character substring function>
   | <fold>
+  | <trim function>
+
+<trim function> /* Expr */ ::=
+  TRIM <left paren> <trim operands> <right paren>   -> trim
+
+<trim operands> /* Expr */ ::=
+    <trim source>                                              -> trim1
+  | FROM <trim source>                                         -> trim1
+  | <trim specification> FROM <trim source>                    -> trim2
+  | <trim character> FROM <trim source>                        -> trim3
+  | <trim specification> <trim character> FROM <trim source>   -> trim4
+
+<trim source> /* Expr */ ::=
+    <character value expression>
+
+<trim specification> /* string */ ::=
+    LEADING
+  | TRAILING
+  | BOTH
+
+<trim character> /* Expr */ ::=
+    <character value expression>
 
 <fold> /* Expr */ ::=
     UPPER <left paren> <character value expression> <right paren>   -> upper

--- a/tests/trim.sql
+++ b/tests/trim.sql
@@ -1,0 +1,44 @@
+EXPLAIN VALUES TRIM('aaababccaa');
+-- EXPLAIN: VALUES (COL1 CHARACTER VARYING) = ROW(TRIM(BOTH ' ' FROM 'aaababccaa'))
+
+EXPLAIN VALUES TRIM(FROM 'aaababccaa');
+-- EXPLAIN: VALUES (COL1 CHARACTER VARYING) = ROW(TRIM(BOTH ' ' FROM 'aaababccaa'))
+
+EXPLAIN VALUES TRIM(LEADING FROM 'aaababccaa');
+-- EXPLAIN: VALUES (COL1 CHARACTER VARYING) = ROW(TRIM(LEADING ' ' FROM 'aaababccaa'))
+
+EXPLAIN VALUES TRIM(TRAILING FROM 'aaababccaa');
+-- EXPLAIN: VALUES (COL1 CHARACTER VARYING) = ROW(TRIM(TRAILING ' ' FROM 'aaababccaa'))
+
+EXPLAIN VALUES TRIM(BOTH FROM 'aaababccaa');
+-- EXPLAIN: VALUES (COL1 CHARACTER VARYING) = ROW(TRIM(BOTH ' ' FROM 'aaababccaa'))
+
+EXPLAIN VALUES TRIM('a' FROM 'aaababccaa');
+-- EXPLAIN: VALUES (COL1 CHARACTER VARYING) = ROW(TRIM(BOTH 'a' FROM 'aaababccaa'))
+
+EXPLAIN VALUES TRIM(LEADING 'a' FROM 'aaababccaa');
+-- EXPLAIN: VALUES (COL1 CHARACTER VARYING) = ROW(TRIM(LEADING 'a' FROM 'aaababccaa'))
+
+VALUES TRIM('aaababccaa');
+-- COL1: aaababccaa
+
+VALUES TRIM(FROM 'aaababccaa');
+-- COL1: aaababccaa
+
+VALUES TRIM(LEADING FROM 'aaababccaa');
+-- COL1: aaababccaa
+
+VALUES TRIM(TRAILING FROM 'aaababccaa');
+-- COL1: aaababccaa
+
+VALUES TRIM(BOTH FROM 'aaababccaa');
+-- COL1: aaababccaa
+
+VALUES TRIM('a' FROM 'aaababccaa');
+-- COL1: babcc
+
+VALUES TRIM(LEADING 'a' FROM 'aaababccaa');
+-- COL1: babccaa
+
+VALUES TRIM(TRAILING 'a' FROM 'aaababccaa');
+-- COL1: aaababcc

--- a/vsql/ast.v
+++ b/vsql/ast.v
@@ -37,6 +37,7 @@ type Expr = BetweenExpr
 	| RowExpr
 	| SimilarExpr
 	| SubstringExpr
+	| TrimExpr
 	| UnaryExpr
 	| Value
 
@@ -101,6 +102,9 @@ fn (e Expr) pstr(params map[string]Value) string {
 			e.pstr(params)
 		}
 		SubstringExpr {
+			e.pstr(params)
+		}
+		TrimExpr {
 			e.pstr(params)
 		}
 		UnaryExpr {
@@ -552,4 +556,18 @@ fn (e SubstringExpr) pstr(params map[string]Value) string {
 	}
 
 	return s + ' USING $e.using)'
+}
+
+struct TrimExpr {
+	specification string // LEADING, TRAILING or BOTH
+	character     Expr   // NoExpr when missing
+	source        Expr
+}
+
+fn (e TrimExpr) str() string {
+	return e.pstr(map[string]Value{})
+}
+
+fn (e TrimExpr) pstr(params map[string]Value) string {
+	return 'TRIM($e.specification ${e.character.pstr(params)} FROM ${e.source.pstr(params)})'
 }

--- a/vsql/expr.v
+++ b/vsql/expr.v
@@ -63,6 +63,11 @@ fn expr_is_agg(conn &Connection, e Expr) ?bool {
 				return nested_agg_unsupported(e)
 			}
 		}
+		TrimExpr {
+			if expr_is_agg(conn, e.source)? || expr_is_agg(conn, e.character)? {
+				return nested_agg_unsupported(e)
+			}
+		}
 	}
 
 	return false
@@ -135,6 +140,10 @@ fn resolve_identifiers(e Expr, tables map[string]Table) ?Expr {
 		CurrentDateExpr, CurrentTimeExpr, CurrentTimestampExpr, LocalTimeExpr, LocalTimestampExpr {
 			// These don't have any Expr properties to recurse.
 			return e
+		}
+		TrimExpr {
+			return TrimExpr{e.specification, resolve_identifiers(e.character, tables)?, resolve_identifiers(e.source,
+				tables)?}
 		}
 	}
 }

--- a/vsql/grammar.v
+++ b/vsql/grammar.v
@@ -1405,6 +1405,39 @@ fn get_grammar() map[string]EarleyRule {
 	mut rule_trigonometric_function_ := &EarleyRule{
 		name: '<trigonometric function>'
 	}
+	mut rule_trim_character_ := &EarleyRule{
+		name: '<trim character>'
+	}
+	mut rule_trim_function_1_ := &EarleyRule{
+		name: '<trim function: 1>'
+	}
+	mut rule_trim_function_ := &EarleyRule{
+		name: '<trim function>'
+	}
+	mut rule_trim_operands_1_ := &EarleyRule{
+		name: '<trim operands: 1>'
+	}
+	mut rule_trim_operands_2_ := &EarleyRule{
+		name: '<trim operands: 2>'
+	}
+	mut rule_trim_operands_3_ := &EarleyRule{
+		name: '<trim operands: 3>'
+	}
+	mut rule_trim_operands_4_ := &EarleyRule{
+		name: '<trim operands: 4>'
+	}
+	mut rule_trim_operands_5_ := &EarleyRule{
+		name: '<trim operands: 5>'
+	}
+	mut rule_trim_operands_ := &EarleyRule{
+		name: '<trim operands>'
+	}
+	mut rule_trim_source_ := &EarleyRule{
+		name: '<trim source>'
+	}
+	mut rule_trim_specification_ := &EarleyRule{
+		name: '<trim specification>'
+	}
 	mut rule_unique_column_list_ := &EarleyRule{
 		name: '<unique column list>'
 	}
@@ -1518,6 +1551,9 @@ fn get_grammar() map[string]EarleyRule {
 	}
 	mut rule_boolean := &EarleyRule{
 		name: 'BOOLEAN'
+	}
+	mut rule_both := &EarleyRule{
+		name: 'BOTH'
 	}
 	mut rule_by := &EarleyRule{
 		name: 'BY'
@@ -1638,6 +1674,9 @@ fn get_grammar() map[string]EarleyRule {
 	}
 	mut rule_key := &EarleyRule{
 		name: 'KEY'
+	}
+	mut rule_leading := &EarleyRule{
+		name: 'LEADING'
 	}
 	mut rule_left := &EarleyRule{
 		name: 'LEFT'
@@ -1783,8 +1822,14 @@ fn get_grammar() map[string]EarleyRule {
 	mut rule_to := &EarleyRule{
 		name: 'TO'
 	}
+	mut rule_trailing := &EarleyRule{
+		name: 'TRAILING'
+	}
 	mut rule_transaction := &EarleyRule{
 		name: 'TRANSACTION'
+	}
+	mut rule_trim := &EarleyRule{
+		name: 'TRIM'
 	}
 	mut rule_true := &EarleyRule{
 		name: 'TRUE'
@@ -2697,6 +2742,11 @@ fn get_grammar() map[string]EarleyRule {
 	rule_character_value_function_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_fold_
+		},
+	]}
+	rule_character_value_function_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_trim_function_
 		},
 	]}
 
@@ -6438,6 +6488,135 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
+	rule_trim_character_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_character_value_expression_
+		},
+	]}
+
+	rule_trim_function_1_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_trim
+		},
+		&EarleyRuleOrString{
+			rule: rule_left_paren_
+		},
+		&EarleyRuleOrString{
+			rule: rule_trim_operands_
+		},
+		&EarleyRuleOrString{
+			rule: rule_right_paren_
+		},
+	]}
+
+	rule_trim_function_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_trim_function_1_
+		},
+	]}
+
+	rule_trim_operands_1_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_trim_source_
+		},
+	]}
+
+	rule_trim_operands_2_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_from
+		},
+		&EarleyRuleOrString{
+			rule: rule_trim_source_
+		},
+	]}
+
+	rule_trim_operands_3_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_trim_specification_
+		},
+		&EarleyRuleOrString{
+			rule: rule_from
+		},
+		&EarleyRuleOrString{
+			rule: rule_trim_source_
+		},
+	]}
+
+	rule_trim_operands_4_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_trim_character_
+		},
+		&EarleyRuleOrString{
+			rule: rule_from
+		},
+		&EarleyRuleOrString{
+			rule: rule_trim_source_
+		},
+	]}
+
+	rule_trim_operands_5_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_trim_specification_
+		},
+		&EarleyRuleOrString{
+			rule: rule_trim_character_
+		},
+		&EarleyRuleOrString{
+			rule: rule_from
+		},
+		&EarleyRuleOrString{
+			rule: rule_trim_source_
+		},
+	]}
+
+	rule_trim_operands_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_trim_operands_1_
+		},
+	]}
+	rule_trim_operands_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_trim_operands_2_
+		},
+	]}
+	rule_trim_operands_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_trim_operands_3_
+		},
+	]}
+	rule_trim_operands_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_trim_operands_4_
+		},
+	]}
+	rule_trim_operands_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_trim_operands_5_
+		},
+	]}
+
+	rule_trim_source_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_character_value_expression_
+		},
+	]}
+
+	rule_trim_specification_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_leading
+		},
+	]}
+	rule_trim_specification_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_trailing
+		},
+	]}
+	rule_trim_specification_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_both
+		},
+	]}
+
 	rule_unique_column_list_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_column_name_list_
@@ -6767,6 +6946,13 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
+	rule_both.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			str: 'BOTH'
+			rule: 0
+		},
+	]}
+
 	rule_by.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			str: 'BY'
@@ -7043,6 +7229,13 @@ fn get_grammar() map[string]EarleyRule {
 	rule_key.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			str: 'KEY'
+			rule: 0
+		},
+	]}
+
+	rule_leading.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			str: 'LEADING'
 			rule: 0
 		},
 	]}
@@ -7383,9 +7576,23 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
+	rule_trailing.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			str: 'TRAILING'
+			rule: 0
+		},
+	]}
+
 	rule_transaction.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			str: 'TRANSACTION'
+			rule: 0
+		},
+	]}
+
+	rule_trim.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			str: 'TRIM'
 			rule: 0
 		},
 	]}
@@ -7936,6 +8143,17 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<trigonometric function name>'] = rule_trigonometric_function_name_
 	rules['<trigonometric function: 1>'] = rule_trigonometric_function_1_
 	rules['<trigonometric function>'] = rule_trigonometric_function_
+	rules['<trim character>'] = rule_trim_character_
+	rules['<trim function: 1>'] = rule_trim_function_1_
+	rules['<trim function>'] = rule_trim_function_
+	rules['<trim operands: 1>'] = rule_trim_operands_1_
+	rules['<trim operands: 2>'] = rule_trim_operands_2_
+	rules['<trim operands: 3>'] = rule_trim_operands_3_
+	rules['<trim operands: 4>'] = rule_trim_operands_4_
+	rules['<trim operands: 5>'] = rule_trim_operands_5_
+	rules['<trim operands>'] = rule_trim_operands_
+	rules['<trim source>'] = rule_trim_source_
+	rules['<trim specification>'] = rule_trim_specification_
 	rules['<unique column list>'] = rule_unique_column_list_
 	rules['<unique constraint definition: 1>'] = rule_unique_constraint_definition_1_
 	rules['<unique constraint definition>'] = rule_unique_constraint_definition_
@@ -7974,6 +8192,7 @@ fn get_grammar() map[string]EarleyRule {
 	rules['BETWEEN'] = rule_between
 	rules['BIGINT'] = rule_bigint
 	rules['BOOLEAN'] = rule_boolean
+	rules['BOTH'] = rule_both
 	rules['BY'] = rule_by
 	rules['CASCADE'] = rule_cascade
 	rules['CEIL'] = rule_ceil
@@ -8014,6 +8233,7 @@ fn get_grammar() map[string]EarleyRule {
 	rules['IS'] = rule_is
 	rules['JOIN'] = rule_join
 	rules['KEY'] = rule_key
+	rules['LEADING'] = rule_leading
 	rules['LEFT'] = rule_left
 	rules['LIKE'] = rule_like
 	rules['LN'] = rule_ln
@@ -8062,7 +8282,9 @@ fn get_grammar() map[string]EarleyRule {
 	rules['TIME'] = rule_time
 	rules['TIMESTAMP'] = rule_timestamp
 	rules['TO'] = rule_to
+	rules['TRAILING'] = rule_trailing
 	rules['TRANSACTION'] = rule_transaction
+	rules['TRIM'] = rule_trim
 	rules['TRUE'] = rule_true
 	rules['UNKNOWN'] = rule_unknown
 	rules['UPDATE'] = rule_update
@@ -8902,6 +9124,30 @@ fn parse_ast_name(children []EarleyValue, name string) ?[]EarleyValue {
 		'<trigonometric function: 1>' {
 			return [
 				EarleyValue(parse_trig_func(children[0] as string, children[2] as Expr)?),
+			]
+		}
+		'<trim function: 1>' {
+			return [EarleyValue(parse_trim(children[2] as Expr)?)]
+		}
+		'<trim operands: 1>' {
+			return [EarleyValue(parse_trim1(children[0] as Expr)?)]
+		}
+		'<trim operands: 2>' {
+			return [EarleyValue(parse_trim1(children[1] as Expr)?)]
+		}
+		'<trim operands: 3>' {
+			return [
+				EarleyValue(parse_trim2(children[0] as string, children[2] as Expr)?),
+			]
+		}
+		'<trim operands: 4>' {
+			return [
+				EarleyValue(parse_trim3(children[0] as Expr, children[2] as Expr)?),
+			]
+		}
+		'<trim operands: 5>' {
+			return [
+				EarleyValue(parse_trim4(children[0] as string, children[1] as Expr, children[3] as Expr)?),
 			]
 		}
 		'<unique constraint definition: 1>' {

--- a/vsql/parse.v
+++ b/vsql/parse.v
@@ -779,3 +779,23 @@ fn parse_substring3(value Expr, from Expr, using string) ?Expr {
 fn parse_substring4(value Expr, from Expr, @for Expr, using string) ?Expr {
 	return SubstringExpr{value, from, @for, using}
 }
+
+fn parse_trim1(source Expr) ?Expr {
+	return TrimExpr{'BOTH', new_varchar_value(' ', 0), source}
+}
+
+fn parse_trim2(specification string, source Expr) ?Expr {
+	return TrimExpr{specification, new_varchar_value(' ', 0), source}
+}
+
+fn parse_trim3(character Expr, source Expr) ?Expr {
+	return TrimExpr{'BOTH', character, source}
+}
+
+fn parse_trim4(specification string, character Expr, source Expr) ?Expr {
+	return TrimExpr{specification, character, source}
+}
+
+fn parse_trim(e Expr) ?Expr {
+	return e
+}


### PR DESCRIPTION
`TRIM` can be constructed in several forms:

    TRIM(
      [ [ { LEADING | TRAILING | BOTH } ] [ trim_character ] FROM ]
      trim_source
    )

If `LEADING`, `TRAILING` or `BOTH` is not provided, `BOTH` is used.

If `trim_character` is not provided, a space (`' '`) is used.

    VALUES TRIM('  hello world ');
    -- COL1: hello world

    VALUES TRIM('a' FROM 'aaababccaa');
    -- COL1: babcc

    VALUES TRIM(LEADING 'a' FROM 'aaababccaa');
    -- COL1: babccaa

    VALUES TRIM(TRAILING 'a' FROM 'aaababccaa');
    -- COL1: aaababcc