### PR TITLE
Added `in` and `out` commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,14 @@ jobs:
         make clean-docs docs
         git diff --exit-code
 
-    - name: Run SQL tests
+    - name: Run SQL and B-tree tests
       run: make test
 
     - name: Run examples
       run: make examples
+
+    - name: Run CLI tests
+      run: make cli-test
 
   macos-binary:
     name: Build for macOS

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,16 @@ btree-test:
 sql-test:
 	v -stats $(BUILD_OPTIONS) test vsql/sql_test.v
 
+# CLI Tests
+
+cli-test: bin/vsql
+	for f in `ls cmd/tests/*.sh`; do \
+		VSQL=bin/vsql ./$$f ; \
+	done
+
+cmd/tests/%: bin/vsql
+	VSQL=bin/vsql ./cmd/tests/$*.sh
+
 # Examples
 
 examples:
@@ -73,8 +83,8 @@ examples/%:
 
 bench: bench-on-disk bench-memory
 
-bench-on-disk: vsql
+bench-on-disk: bin/vsql
 	./bin/vsql bench
 
-bench-memory: vsql
+bench-memory: bin/vsql
 	./bin/vsql bench -file ':memory:'

--- a/cmd/tests/README.md
+++ b/cmd/tests/README.md
@@ -1,0 +1,1 @@
+See https://vsql.readthedocs.io/en/latest/testing.html#cli for documentation.

--- a/cmd/tests/in-continue-on-error.sh
+++ b/cmd/tests/in-continue-on-error.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+VSQL_FILE="$(mktemp).vsql" || exit 1
+SQL_FILE="$(mktemp).sql" || exit 1
+
+# By default, errors will stop the process and return a non-zero exit code.
+(printf '%s\n' \
+    'CREATE foo (bar INT);' \
+    'CREATE TABLE bar (bar INT);' \
+| $VSQL in $VSQL_FILE) && exit 1 || true
+
+$VSQL out $VSQL_FILE > $SQL_FILE
+grep -vR "CREATE TABLE PUBLIC.BAR" $SQL_FILE
+
+# Enable continue on error still returns the non-zero exit code.
+(printf '%s\n' \
+    'CREATE foo (bar INT);' \
+    'CREATE TABLE bar (bar INT);' \
+| $VSQL in -continue-on-error $VSQL_FILE) && exit 1 || true
+
+$VSQL out $VSQL_FILE > $SQL_FILE
+grep -R "CREATE TABLE PUBLIC.BAR" $SQL_FILE

--- a/cmd/tests/in-verbose.sh
+++ b/cmd/tests/in-verbose.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+VSQL_FILE="$(mktemp).vsql" || exit 1
+TXT_FILE="$(mktemp).sql" || exit 1
+
+(printf '%s\n' \
+    'CREATE TABLE foo (bar INT);' \
+    'INSERT INTO foo (bar) VALUES (123);' \
+| $VSQL in -verbose $VSQL_FILE
+) > $TXT_FILE
+
+grep -R "CREATE TABLE 1" $TXT_FILE
+grep -R "INSERT 1" $TXT_FILE

--- a/cmd/tests/in.sh
+++ b/cmd/tests/in.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -ex
+
+VSQL_FILE="$(mktemp).vsql" || exit 1
+SQL_FILE="$(mktemp).sql" || exit 1
+
+# Loading into a new file.
+echo 'CREATE TABLE foo (bar INT);' | $VSQL in $VSQL_FILE
+
+$VSQL out $VSQL_FILE > $SQL_FILE
+grep -R "CREATE TABLE PUBLIC.FOO" $SQL_FILE
+
+# Loading into an existing file.
+echo 'CREATE TABLE bar (bar INT);' | $VSQL in $VSQL_FILE
+
+$VSQL out $VSQL_FILE > $SQL_FILE
+grep -R "CREATE TABLE PUBLIC.FOO" $SQL_FILE
+grep -R "CREATE TABLE PUBLIC.BAR" $SQL_FILE

--- a/cmd/tests/missing-command.sh
+++ b/cmd/tests/missing-command.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+$VSQL && exit 0

--- a/cmd/tests/out-create-public-schema.sh
+++ b/cmd/tests/out-create-public-schema.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+
+VSQL_FILE="$(mktemp).vsql" || exit 1
+SQL_FILE="$(mktemp).sql" || exit 1
+
+echo 'CREATE TABLE foo (bar INT);' | $VSQL in $VSQL_FILE
+
+# Default behavior does not include "CREATE SCHEMA PUBLIC"
+$VSQL out $VSQL_FILE > $SQL_FILE
+
+grep -vR "CREATE SCHEMA PUBLIC" $SQL_FILE
+grep -R "CREATE TABLE PUBLIC.FOO" $SQL_FILE
+
+# Now include in output.
+$VSQL out -create-public-schema $VSQL_FILE > $SQL_FILE
+
+grep -R "CREATE SCHEMA PUBLIC" $SQL_FILE
+grep -R "CREATE TABLE PUBLIC.FOO" $SQL_FILE

--- a/cmd/tests/unknown-command.sh
+++ b/cmd/tests/unknown-command.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+$VSQL no-such-command && exit 0

--- a/cmd/tests/version.sh
+++ b/cmd/tests/version.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+# This should print out "no version information available" which isn't that
+# helpful. But mainly we just want this test to make sure it accepts the version
+# command.
+
+$VSQL version

--- a/cmd/vsql/in.v
+++ b/cmd/vsql/in.v
@@ -1,0 +1,75 @@
+module main
+
+import cli
+import os
+import vsql
+
+fn register_in_command(mut cmd cli.Command) {
+	mut in_cmd := cli.Command{
+		name: 'in'
+		usage: '<file>'
+		required_args: 1
+		description: 'Import schema and data'
+		execute: in_command
+	}
+
+	in_cmd.add_flag(cli.Flag{
+		flag: .bool
+		name: 'continue-on-error'
+		description: 'Continue when errors occur'
+	})
+
+	in_cmd.add_flag(cli.Flag{
+		flag: .bool
+		name: 'verbose'
+		abbrev: 'v'
+		description: 'Show result of each command'
+	})
+
+	cmd.add_command(in_cmd)
+}
+
+fn in_command(cmd cli.Command) ? {
+	mut db := vsql.open(cmd.args[0])?
+	mut f := os.stdin()
+
+	// Keep running stats for the end.
+	mut stmt_count := 0
+	mut error_count := 0
+	timer := vsql.start_timer()
+
+	mut stmt := ''
+	for !f.eof() {
+		mut buf := []u8{len: 100}
+		f.read_bytes_into_newline(mut buf)?
+		line := buf.bytestr()
+		stmt += line.trim_right('\0 \n;')
+
+		if line.contains(';') {
+			result := db.query(stmt) or {
+				println(err)
+				error_count++
+				vsql.Result{}
+			}
+
+			if cmd.flags.get_bool('verbose') or { false } {
+				for row in result {
+					msg := row.get_string('msg') or { '' }
+					if msg != '' {
+						println(msg)
+						break
+					}
+				}
+			}
+
+			stmt_count++
+			stmt = ''
+		}
+	}
+
+	println('$error_count errors, $stmt_count statements, $timer.elapsed()')
+
+	if error_count > 0 {
+		exit(1)
+	}
+}

--- a/cmd/vsql/main.v
+++ b/cmd/vsql/main.v
@@ -7,13 +7,21 @@ fn main() {
 	mut cmd := cli.Command{
 		name: 'vsql'
 		description: 'vsql is a single-file or PostgeSQL-compatible SQL database written in V.\nhttps://github.com/elliotchance/vsql'
+		execute: unknown_command
 	}
 
 	register_bench_command(mut cmd)
 	register_cli_command(mut cmd)
+	register_in_command(mut cmd)
+	register_out_command(mut cmd)
 	register_server_command(mut cmd)
 	register_version_command(mut cmd)
 
 	cmd.setup()
 	cmd.parse(os.args)
+}
+
+fn unknown_command(_ cli.Command) ? {
+	println('unknown or missing command, see "vsql help"')
+	exit(1)
 }

--- a/cmd/vsql/out.v
+++ b/cmd/vsql/out.v
@@ -1,0 +1,59 @@
+module main
+
+import cli
+import vsql
+
+fn register_out_command(mut cmd cli.Command) {
+	mut out_cmd := cli.Command{
+		name: 'out'
+		usage: '<file>'
+		required_args: 1
+		description: 'Export schema and data'
+		execute: out_command
+	}
+
+	out_cmd.add_flag(cli.Flag{
+		flag: .bool
+		name: 'create-public-schema'
+		description: 'Include "CREATE SCHEMA PUBLIC"'
+	})
+
+	cmd.add_command(out_cmd)
+}
+
+fn out_command(cmd cli.Command) ? {
+	mut db := vsql.open(cmd.args[0])?
+
+	// To make the output more deterministic the schemas and tables will ordered
+	// by name. This is not true for the records however, which can potentially
+	// come out in any order.
+	mut schemas := db.schemas()?
+	schemas.sort(a.name > b.name)
+
+	for _, schema in schemas {
+		// We avoid "CREATE SCHEMA PUBLIC;" because it would break the import.
+		// Although, `-create-public-schema` can be used to enable it when
+		// dealing with other databases.
+		if schema.name == 'PUBLIC' && cmd.flags.get_bool('create-public-schema') or { false } {
+			println('$schema\n')
+		}
+
+		mut tables := db.schema_tables(schema.name)?
+		tables.sort(a.name > b.name)
+
+		for _, table in tables {
+			println('$table\n')
+
+			for row in db.query('SELECT * FROM $table.name')? {
+				mut data := []string{}
+				for col in table.column_names() {
+					data << (row.get(col)?).str()
+				}
+
+				println('INSERT INTO $table.name (${table.column_names().join(', ')}) VALUES (${data.join(', ')});')
+			}
+
+			println('')
+		}
+	}
+}

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,25 +1,117 @@
 Command Line Interface (CLI)
 ============================
 
-You can also work with database files through the CLI (ctrl+c to exit):
+.. contents::
 
-.. code-block:: text
-
-   $ vsql test.vsql
-   vsql> select * from foo
-   A: 1234 
-   1 row (1 ms)
-
-   vsql> select * from bar
-   0 rows (0 ms)
+Installing
+----------
 
 Binary releases can be downloaded from the
 `Releases <https://github.com/elliotchance/vsql/releases>`_ page (under Assets).
 
-These binary releases do not require V to be installed. Or, you can compile from
-source with:
+These binary releases do not require V to be installed.
+
+Compiling From Source
+---------------------
+
+You can compile from source with:
 
 .. code-block:: sh
 
    make bin/vsql       # macOS and linux
    make bin/vsql.exe   # windows
+
+Commands
+--------
+
+bench
+^^^^^
+
+``bench`` is used to run benchmarks:
+
+.. code-block:: sh
+
+   vsql bench                    # on disk
+   vsql bench -file ':memory:'   # in memory
+
+cli
+^^^
+
+``cli`` provides a command prompt for running SQL commands (ctrl+c to exit):
+
+.. code-block:: text
+
+   $ vsql cli test.vsql
+   vsql> select * from foo;
+   A: 1234 
+   1 row (1 ms)
+
+   vsql> select * from bar;
+   0 rows (0 ms)
+
+in
+^^^
+
+``in`` is used to load a SQL file into a database:
+
+.. code-block:: text
+
+   $ vsql in mydatabase.vsql < myfile.sql
+   0 errors, 8 statements, 98.042ms
+
+You can generate a valid SQL file from an existing database with ``vsql out``.
+
+Options are:
+
+- ``-continue-on-error``: Show errors, but continue to process the input. A
+  non-zero exit code will be returned if any of the statements failed.
+
+- ``-verbose`` or ``-v``: When enabled, the output of each statement (such as
+  ``CREATE TABLE 1``) will be shown.
+
+out
+^^^
+
+``out`` will export schema and data in SQL format:
+
+.. code-block:: text
+
+   $ vsql out mydatabase.vsql > myfile.sql
+   $ cat myfile.sql
+   CREATE TABLE PUBLIC.BAR (
+      X INTEGER
+   );
+
+   INSERT INTO PUBLIC.BAR (X) VALUES (1234);
+
+The output can be loaded into a database with the ``in`` command.
+
+Options are:
+
+- ``-create-public-schema``: When enabled, ``CREATE SCHEMA PUBLIC;`` will be
+  included in the output. By default it not included because it is provided
+  implicitly with a vsql database.
+
+server
+^^^^^^
+
+``server`` will start the PostgreSQL-compatible server. You may connect to it
+with on of the :doc:`supported PostgreSQL clients here<postgresql-clients>`.
+
+.. code-block:: sh
+
+   vsql server
+
+Options are:
+
+- ``--port`` or ``-p``: Port number (default 3210).
+- ``--verbose`` or ``-v``: Verbose (show all messages in and out of the server).
+
+version
+^^^^^^^
+
+Is used to display the current version:
+
+.. code-block:: sh
+
+   vsql version

--- a/docs/snippets.rst
+++ b/docs/snippets.rst
@@ -47,11 +47,11 @@
    runtime to a virtual table.
 
 .. |v.Connection.schema_tables| replace::
-   schema_tables returns all table names for the provided schema. If the schema
-   does not exist and empty list will be returned.
+   schema_tables returns tables for the provided schema. If the schema does not
+   exist and empty list will be returned.
 
 .. |v.Connection.schemas| replace::
-   schemas returns the names of schemas in this catalog (database).
+   schemas returns the schemas in this catalog (database).
 
 .. |v.ConnectionOptions| replace::
    ConnectionOptions can modify the behavior of a connection when it is opened.
@@ -179,6 +179,40 @@
 
 .. |v.SQLType.str| replace::
    The SQL representation, such as ``TIME WITHOUT TIME ZONE``.
+
+.. |v.Schema| replace::
+   Represents a schema.
+
+.. |v.Schema.name| replace::
+   The name of the schema is case-sensitive.
+
+.. |v.Schema.str| replace::
+   Returns the CREATE SCHEMA statement for this schema, including the ';'.
+
+.. |v.Table| replace::
+   Represents the structure of a table.
+
+.. |v.Table.column| replace::
+   Find a column by name, or return a SQLSTATE 42703 error.
+
+.. |v.Table.column_names| replace::
+   Convenience method for returning the ordered list of column names.
+
+.. |v.Table.columns| replace::
+   The column definitions for the table.
+
+.. |v.Table.is_virtual| replace::
+   When the table is virtual it is not persisted to disk.
+
+.. |v.Table.name| replace::
+   The name of the table is case-sensitive.
+
+.. |v.Table.primary_key| replace::
+   If the table has a PRIMARY KEY defined the column (or columns) will be
+   defined here in order.
+
+.. |v.Table.str| replace::
+   Returns the CREATE TABLE statement, including the ';'.
 
 .. |v.Time| replace::
    Time is the internal way that time is represented and provides other

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -31,6 +31,78 @@ suite alone with:
 
    make btree-test
 
+CLI
+^^^
+
+CLI tests are a collection of shell scripts that are executed. The vast majority
+of these are used to test the ``vsql`` executable itself, however, since they
+are shell scripts they are not limited to this.
+
+To run all CLI tests:
+
+.. code-block:: sh
+
+   make cli-tests
+
+Or, to run a single command test use the path without the ``.sh`` suffix:
+
+.. code-block:: sh
+
+   make cmd/tests/in-success
+
+Each shell file must return a 0 (success) exit code. However, there are many
+ways to verify that certain commands fail on purpose within the script itself.
+
+There are some things to consider when writing CLI tests:
+
+1. The file must end with ``.sh`` and contain a
+`https://en.wikipedia.org/wiki/Shebang_(Unix) <shebang>`_ on the first line.
+
+2. Remember to put ``set -e`` before any other commands. This will ensure that
+if a command fails, that the script itself will halt and return the exit code.
+
+3. A ``$VSQL`` will be provided for the true location of the ``vsql``
+executable, you should not hardcode the binary location. This also makes it easy
+to test the same scripts against different versions of vsql in the future.
+
+Debugging
+*********
+
+Modify the ``set -e`` at the start of the file to be ``set -ex``. This will
+print out each of the commmands before they run.
+
+Temporary Files
+***************
+
+Your test files should make temporary files as needed. This will prevent race
+conditions and other errors with inconsistent state. Create a temporary file
+with (replace the ``.vsql`` extension, if needed):
+
+.. code-block:: sh
+
+   VSQL_FILE="$(mktemp).vsql" || exit 1
+
+Assertions
+**********
+
+You can use the following to verify that a file contains a string (it will not
+match the whole line):
+
+.. code-block:: sh
+
+   grep -R "CREATE TABLE PUBLIC.FOO" $SQL_FILE
+
+Conversely, ``grep -vR`` can be used to check a file does not contain a string.
+
+To verify that a command failed (specifically did not succeed), you can use:
+
+.. code-block:: sh
+
+   (echo 'CREATE foo (bar INT);' | $VSQL in $VSQL_FILE) && exit 1 || true
+
+Where ``echo 'CREATE foo (bar INT);' | $VSQL in $VSQL_FILE`` is the command to
+be tested.
+
 Examples
 ^^^^^^^^
 

--- a/docs/v-client-library.rst
+++ b/docs/v-client-library.rst
@@ -124,12 +124,12 @@ fn Connection.register_virtual_table(create_table string, data VirtualTableProvi
 
 |v.Connection.register_virtual_table|
 
-fn Connection.schemas() []string
-********************************
+fn Connection.schemas() ?[]Schema
+*********************************
 
 |v.Connection.schemas|
 
-fn Connection.schema_tables(schema string) []string
+fn Connection.schema_tables(schema string) ?[]Table
 ***************************************************
 
 |v.Connection.schema_tables|
@@ -240,6 +240,21 @@ get(name string) ?Value
 
 |v.Row.get|
 
+struct Schema
+^^^^^^^^^^^^^
+
+|v.Schema|
+
+name string
+***********
+
+|v.Schema.name|
+
+fn Schema.str() string
+**********************
+
+|v.Schema.str|
+
 struct SQLState
 ^^^^^^^^^^^^^^^
 
@@ -277,6 +292,46 @@ fn SQLType.str() string
 ***********************
 
 |v.SQLType.str|
+
+struct Table
+^^^^^^^^^^^^
+
+|v.Table|
+
+columns Columns
+***************
+
+|v.Table.columns|
+
+is_virtual bool
+***************
+
+|v.Table.is_virtual|
+
+name string
+***********
+
+|v.Table.name|
+
+primary_key []string
+********************
+
+|v.Table.primary_key|
+
+fn Table.column(name string) ?Column
+************************************
+
+|v.Table.column|
+
+fn Table.column_names() []string
+********************************
+
+|v.Table.column_names|
+
+fn Table.str() string
+*********************
+
+|v.Table.str|
 
 struct Time
 ^^^^^^^^^^^

--- a/vsql/connection.v
+++ b/vsql/connection.v
@@ -273,27 +273,37 @@ pub fn (mut c Connection) register_virtual_table(create_table string, data Virtu
 	return error('must provide a CREATE TABLE statement')
 }
 
-// schemas returns the names of schemas in this catalog (database).
+// schemas returns the schemas in this catalog (database).
 //
 // snippet: v.Connection.schemas
-pub fn (mut c Connection) schemas() []string {
-	mut schemas := []string{}
+pub fn (mut c Connection) schemas() ?[]Schema {
+	c.open_read_connection()?
+	defer {
+		c.release_read_connection()
+	}
+
+	mut schemas := []Schema{}
 	for _, schema in c.storage.schemas {
-		schemas << schema.name
+		schemas << schema
 	}
 
 	return schemas
 }
 
-// schema_tables returns all table names for the provided schema. If the schema
-// does not exist and empty list will be returned.
+// schema_tables returns tables for the provided schema. If the schema does not
+// exist and empty list will be returned.
 //
 // snippet: v.Connection.schema_tables
-pub fn (mut c Connection) schema_tables(schema string) []string {
-	mut tables := []string{}
+pub fn (mut c Connection) schema_tables(schema string) ?[]Table {
+	c.open_read_connection()?
+	defer {
+		c.release_read_connection()
+	}
+
+	mut tables := []Table{}
 	for _, table in c.storage.tables {
 		if table.name.starts_with('${schema}.') {
-			tables << table.name.split('.')[1]
+			tables << table
 		}
 	}
 

--- a/vsql/result.v
+++ b/vsql/result.v
@@ -10,7 +10,7 @@ import time
 // See next() for an example on iterating rows in a Result.
 //
 // snippet: v.Result
-struct Result {
+pub struct Result {
 	// rows is not public because in the future this may end up being a cursor.
 	// You should use V iteration to read the rows.
 	rows []Row

--- a/vsql/schema.v
+++ b/vsql/schema.v
@@ -2,10 +2,17 @@
 
 module vsql
 
-struct Schema {
-	name string
+// Represents a schema.
+//
+// snippet: v.Schema
+pub struct Schema {
 	// The tid is the transaction ID that created this table.
 	tid int
+pub:
+	// The name of the schema is case-sensitive.
+	//
+	// snippet: v.Schema.name
+	name string
 }
 
 fn (s Schema) bytes() []u8 {
@@ -20,5 +27,12 @@ fn new_schema_from_bytes(data []u8, tid int) Schema {
 
 	schema_name := b.read_string1()
 
-	return Schema{schema_name, tid}
+	return Schema{tid, schema_name}
+}
+
+// Returns the CREATE SCHEMA statement for this schema, including the ';'.
+//
+// snippet: v.Schema.str
+fn (s Schema) str() string {
+	return 'CREATE SCHEMA $s.name;'
 }

--- a/vsql/storage.v
+++ b/vsql/storage.v
@@ -116,7 +116,7 @@ fn (mut f Storage) create_table(table_name string, columns Columns, primary_key 
 		f.isolation_end() or { panic(err) }
 	}
 
-	table := Table{table_name, columns, primary_key, f.transaction_id, false}
+	table := Table{f.transaction_id, table_name, columns, primary_key, false}
 
 	obj := new_page_object('T$table_name'.bytes(), f.transaction_id, 0, table.bytes())
 	page_number := f.btree.add(obj)?
@@ -132,7 +132,7 @@ fn (mut f Storage) create_schema(schema_name string) ? {
 		f.isolation_end() or { panic(err) }
 	}
 
-	schema := Schema{schema_name, f.transaction_id}
+	schema := Schema{f.transaction_id, schema_name}
 
 	obj := new_page_object('S$schema_name'.bytes(), f.transaction_id, 0, schema.bytes())
 	page_number := f.btree.add(obj)?

--- a/vsql/timer.v
+++ b/vsql/timer.v
@@ -4,16 +4,16 @@ module vsql
 
 import time
 
-struct Timer {
+pub struct Timer {
 	started_at time.Time
 }
 
-fn start_timer() Timer {
+pub fn start_timer() Timer {
 	return Timer{
 		started_at: time.now()
 	}
 }
 
-fn (t Timer) elapsed() time.Duration {
+pub fn (t Timer) elapsed() time.Duration {
 	return time.now() - t.started_at
 }

--- a/vsql/value.v
+++ b/vsql/value.v
@@ -225,7 +225,7 @@ fn (v Value) as_int() i64 {
 // formatting.
 //
 // snippet: v.Value.str
-fn (v Value) str() string {
+pub fn (v Value) str() string {
 	if v.is_null && v.typ.typ != .is_boolean {
 		return 'NULL'
 	}


### PR DESCRIPTION
`vsql in` will execute a SQL file and `vsql out` can be used to dump the
structure and data from a database in SQL format. These are also useful
when converting data to and from other databases.

The commands are designed to be simple and provide a means to make a
lossless copy (or a backup) of a database without any other options:

    vsql out mydb.vsql > mydb.sql
    vsql in mydb.vsql < mydb.sql

This is also especially important if there are changes to the vsql file
format in the future. To be able to quickly and easily recreate the
database.

You can find more CLI options and documentation for these commands here:
https://vsql.readthedocs.io/en/latest/cli.html

To facilitate testing, there is now a 5th test suite called
"CLI Tests" which are written as shell scripts and executed along with
the other suites. This provides a lot of flexibility in testing CLI
options, exit codes, outputs, etc. You can read how CLI Tests work here:
https://vsql.readthedocs.io/en/latest/testing.html#cli