### PR TITLE
Fix notice about unitialised interface pager field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,20 @@ on:
     paths-ignore:
       - '**.md'
       - '**.rst'
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - "**.rst"
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   tests:
     name: Tests
     runs-on: macos-latest
+    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master'	
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -42,6 +51,7 @@ jobs:
   macos-binary:
     name: Build for macOS
     runs-on: macos-latest
+    if: github.event.ref == 'refs/heads/master'	
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -67,6 +77,7 @@ jobs:
 
   linux-binary:
     name: Build for Linux
+    if: github.event.ref == 'refs/heads/master'	
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -96,6 +107,7 @@ jobs:
   # put in a PR to fix this.
   windows-binary:
     name: Build for Windows
+    if: github.event.ref == 'refs/heads/master'	
     runs-on: macos-latest
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,117 +18,114 @@ jobs:
   tests:
     name: Tests
     runs-on: macos-latest
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master'	
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set up V version latest
-      uses: nocturlab/setup-vlang-action@v1
-      with:
-        v-version: master
-      id: v
+      - name: Set up V version latest
+        uses: nocturlab/setup-vlang-action@v1
+        with:
+          id: v
+          v-version: master
 
-    - name: Verify fmt
-      run: make fmt-verify
+      - name: Verify fmt
+        run: make fmt-verify
 
-    - name: Verify docs
-      run: |
-        pip install sphinx sphinx_rtd_theme
-        cd docs && python3 -m pip install -r requirements.txt && cd -
-        make clean-docs docs
-        git diff --exit-code
+      - name: Verify docs
+        run: |
+          pip install sphinx sphinx_rtd_theme
+          cd docs && python3 -m pip install -r requirements.txt && cd -
+          make clean-docs docs
+          git diff --exit-code
 
-    - name: Run SQL and B-tree tests
-      run: make test
+      - name: Run SQL and B-tree tests
+        run: make test
 
-    - name: Run examples
-      run: make examples
+      - name: Run examples
+        run: make examples
 
-    - name: Run CLI tests
-      run: make cli-test
+      - name: Run CLI tests
+        run: make cli-test
 
   macos-binary:
     name: Build for macOS
     runs-on: macos-latest
-    if: github.event.ref == 'refs/heads/master'	
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set up V version latest
-      uses: nocturlab/setup-vlang-action@v1
-      with:
-        v-version: master
-      id: v
+      - name: Set up V version latest
+        uses: nocturlab/setup-vlang-action@v1
+        with:
+          id: v
+          v-version: master
 
-    - name: Build macOS binaries
-      run: |
-        sed -i -e "s/MISSING_VERSION/${GITHUB_REF##*/} `date +'%F'`/g" cmd/vsql/version.v
-        make bin/vsql
-        zip -j vsql-macos.zip bin/vsql
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: |
-          vsql-macos.zip
+      - name: Build macOS binaries
+        run: |
+          .github/workflows/set_version.sh
+          make bin/vsql
+          zip -j vsql-macos.zip bin/vsql
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            vsql-macos.zip
 
   linux-binary:
     name: Build for Linux
-    if: github.event.ref == 'refs/heads/master'	
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set up V version latest
-      uses: nocturlab/setup-vlang-action@v1
-      with:
-        v-version: master
-      id: v
+      - name: Set up V version latest
+        uses: nocturlab/setup-vlang-action@v1
+        with:
+          id: v
+          v-version: master
 
-    - name: Build linux binaries
-      run: |
-        sed -i -e "s/MISSING_VERSION/${GITHUB_REF##*/} `date +'%F'`/g" cmd/vsql/version.v
-        make bin/vsql
-        zip -j vsql-linux.zip bin/vsql
+      - name: Build linux binaries
+        run: |
+          .github/workflows/set_version.sh
+          make bin/vsql
+          zip -j vsql-linux.zip bin/vsql
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: |
-          vsql-linux.zip
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            vsql-linux.zip
 
   # I know it seems pretty silly that we're using macOS and cross compling for
   # Windows. But I couldn't get window-latest to work. If you use windows please
   # put in a PR to fix this.
   windows-binary:
     name: Build for Windows
-    if: github.event.ref == 'refs/heads/master'	
     runs-on: macos-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set up V version latest
-      uses: nocturlab/setup-vlang-action@v1
-      with:
-        v-version: master
-      id: v
+      - name: Set up V version latest
+        uses: nocturlab/setup-vlang-action@v1
+        with:
+          id: v
+          v-version: master
 
-    - name: Build Windows binaries
-      run: |
-        brew install mingw-w64
-        v -os windows -prod cmd/vsql
-        mv cmd/vsql/vsql.exe bin/vsql.exe
-        zip -j vsql-windows.zip bin/vsql.exe
+      - name: Build Windows binaries
+        run: |
+          brew install mingw-w64
+          v -os windows -prod cmd/vsql
+          mv cmd/vsql/vsql.exe bin/vsql.exe
+          zip -j vsql-windows.zip bin/vsql.exe
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: |
-          vsql-windows.zip
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            vsql-windows.zip

--- a/.github/workflows/set_version.sh
+++ b/.github/workflows/set_version.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sed -i -e "s/MISSING_VERSION/${GITHUB_REF##*/} `date +'%F'`/g" cmd/vsql/version.v

--- a/cmd/vsql/bench.v
+++ b/cmd/vsql/bench.v
@@ -26,8 +26,8 @@ fn bench_command(cmd cli.Command) ? {
 		file = 'bench.vsql'
 	}
 
-	mut conn := vsql.open(':memory:') or { panic('$err') }
+	mut conn := vsql.open(':memory:') or { panic('${err}') }
 
 	mut benchmark := vsql.new_benchmark(conn)
-	benchmark.start() or { panic('$err') }
+	benchmark.start() or { panic('${err}') }
 }

--- a/cmd/vsql/cli.v
+++ b/cmd/vsql/cli.v
@@ -32,7 +32,7 @@ fn cli_command(cmd cli.Command) ? {
 			mut total_rows := 0
 			for row in result {
 				for column in result.columns {
-					print('$column.name: ${row.get_string(column.name)} ')
+					print('${column.name}: ${row.get_string(column.name)} ')
 				}
 				total_rows++
 			}
@@ -41,7 +41,7 @@ fn cli_command(cmd cli.Command) ? {
 				println('')
 			}
 
-			println('$total_rows ${vsql.pluralize(total_rows, 'row')} (${time.ticks() - start} ms)')
+			println('${total_rows} ${vsql.pluralize(total_rows, 'row')} (${time.ticks() - start} ms)')
 		}
 
 		println('')

--- a/cmd/vsql/in.v
+++ b/cmd/vsql/in.v
@@ -69,7 +69,7 @@ fn in_command(cmd cli.Command) ? {
 		}
 	}
 
-	println('$error_count errors, $stmt_count statements, $timer.elapsed()')
+	println('${error_count} errors, ${stmt_count} statements, ${timer.elapsed()}')
 
 	if error_count > 0 {
 		exit(1)

--- a/cmd/vsql/out.v
+++ b/cmd/vsql/out.v
@@ -36,7 +36,7 @@ fn out_command(cmd cli.Command) ? {
 		// Although, `-create-public-schema` can be used to enable it when
 		// dealing with other databases.
 		if schema.name == 'PUBLIC' && cmd.flags.get_bool('create-public-schema') or { false } {
-			println('$schema\n')
+			println('${schema}\n')
 		}
 
 		mut tables := db.schema_tables(schema.name) or { return err }
@@ -44,15 +44,15 @@ fn out_command(cmd cli.Command) ? {
 		tables.sort(a.name > b.name)
 
 		for _, table in tables {
-			println('$table\n')
+			println('${table}\n')
 
-			for row in db.query('SELECT * FROM $table.name')! {
+			for row in db.query('SELECT * FROM ${table.name}')! {
 				mut data := []string{}
 				for col in table.column_names() {
 					data << (row.get(col)!).str()
 				}
 
-				println('INSERT INTO $table.name (${table.column_names().join(', ')}) VALUES (${data.join(', ')});')
+				println('INSERT INTO ${table.name} (${table.column_names().join(', ')}) VALUES (${data.join(', ')});')
 			}
 
 			println('')

--- a/cmd/vsql/version.v
+++ b/cmd/vsql/version.v
@@ -23,6 +23,6 @@ fn print_version() {
 	if version.contains('MISSING') {
 		println('no version information available')
 	} else {
-		println('vsql $version')
+		println('vsql ${version}')
 	}
 }

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -31,6 +31,18 @@ suite alone with:
 
    make btree-test
 
+Note: by default, btree_test.v will do just one iteration, which is faster,
+and ok while developing, but before making a PR or a release, you should use:
+
+.. code-block:: sh
+
+   TIMES=10 make btree-test
+
+or even ideally:
+.. code-block:: sh
+
+   TIMES=100 make btree-test
+
 CLI
 ^^^
 

--- a/examples/error-handling.v
+++ b/examples/error-handling.v
@@ -11,7 +11,7 @@ fn example() ! {
 
 	db.query('SELECT * FROM bar') or {
 		sqlstate := vsql.sqlstate_from_int(err.code())
-		println('$sqlstate: $err.msg()')
+		println('${sqlstate}: ${err.msg()}')
 		// 42P01: no such table: BAR
 
 		if err.code() == vsql.sqlstate_to_int('42P01') {
@@ -22,7 +22,7 @@ fn example() ! {
 	db.query('SELECT * FROM bar') or {
 		match err {
 			vsql.SQLState42P01 { // 42P01 = table not found
-				println("I knew '$err.table_name' did not exist!")
+				println("I knew '${err.table_name}' did not exist!")
 			}
 			else {
 				panic(err)

--- a/examples/show-tables.v
+++ b/examples/show-tables.v
@@ -22,8 +22,8 @@ fn example() ! {
 			table_names << table.name
 		}
 
-		println('$schema.name has $table_names')
-		actual << '$schema.name has $table_names'
+		println('${schema.name} has ${table_names}')
+		actual << '${schema.name} has ${table_names}'
 	}
 
 	assert actual == [

--- a/examples/virtual-tables.v
+++ b/examples/virtual-tables.v
@@ -38,6 +38,6 @@ fn example() ! {
 	for row in result {
 		num := row.get_f64('num')!
 		word := row.get_string('WORD')!
-		println('$num $word')
+		println('${num} ${word}')
 	}
 }

--- a/vsql/ast.v
+++ b/vsql/ast.v
@@ -132,7 +132,7 @@ fn (e Expr) pstr(params map[string]Value) string {
 		}
 		Value {
 			if e.typ.uses_string() || e.typ.uses_time() {
-				'\'$e.str()\''
+				'\'${e.str()}\''
 			} else {
 				e.str()
 			}
@@ -289,7 +289,7 @@ fn (e UnaryExpr) str() string {
 }
 
 fn (e UnaryExpr) pstr(params map[string]Value) string {
-	return '$e.op ${e.expr.pstr(params)}'
+	return '${e.op} ${e.expr.pstr(params)}'
 }
 
 struct BinaryExpr {
@@ -303,7 +303,7 @@ fn (e BinaryExpr) str() string {
 }
 
 fn (e BinaryExpr) pstr(params map[string]Value) string {
-	return '${e.left.pstr(params)} $e.op ${e.right.pstr(params)}'
+	return '${e.left.pstr(params)} ${e.op} ${e.right.pstr(params)}'
 }
 
 // NoExpr is just a placeholder when there is no expression provided.
@@ -326,7 +326,7 @@ fn (e CallExpr) str() string {
 
 fn (e CallExpr) pstr(params map[string]Value) string {
 	args := e.args.map(it.pstr(params)).join(', ')
-	return '${e.function_name}($args)'
+	return '${e.function_name}(${args})'
 }
 
 struct ComparisonPredicatePart2 {
@@ -359,7 +359,7 @@ fn (c Correlation) str() string {
 		return ''
 	}
 
-	mut s := ' AS $c.name'
+	mut s := ' AS ${c.name}'
 
 	if c.columns.len > 0 {
 		mut columns := []string{}
@@ -380,14 +380,14 @@ struct Parameter {
 }
 
 fn (e Parameter) str() string {
-	return ':$e.name'
+	return ':${e.name}'
 }
 
 fn (e Parameter) pstr(params map[string]Value) string {
 	p := params[e.name]
 
 	if p.typ.uses_string() || p.typ.uses_time() {
-		return '\'$p.str()\''
+		return '\'${p.str()}\''
 	}
 
 	return p.str()
@@ -517,7 +517,7 @@ struct CurrentTimeExpr {
 }
 
 fn (e CurrentTimeExpr) str() string {
-	return 'CURRENT_TIME($e.prec)'
+	return 'CURRENT_TIME(${e.prec})'
 }
 
 struct CurrentTimestampExpr {
@@ -525,7 +525,7 @@ struct CurrentTimestampExpr {
 }
 
 fn (e CurrentTimestampExpr) str() string {
-	return 'CURRENT_TIMESTAMP($e.prec)'
+	return 'CURRENT_TIMESTAMP(${e.prec})'
 }
 
 struct LocalTimeExpr {
@@ -533,7 +533,7 @@ struct LocalTimeExpr {
 }
 
 fn (e LocalTimeExpr) str() string {
-	return 'LOCALTIME($e.prec)'
+	return 'LOCALTIME(${e.prec})'
 }
 
 struct LocalTimestampExpr {
@@ -541,7 +541,7 @@ struct LocalTimestampExpr {
 }
 
 fn (e LocalTimestampExpr) str() string {
-	return 'LOCALTIMESTAMP($e.prec)'
+	return 'LOCALTIMESTAMP(${e.prec})'
 }
 
 struct CreateSchemaStmt {
@@ -575,7 +575,7 @@ fn (e SubstringExpr) pstr(params map[string]Value) string {
 		s += ' FOR ${e.@for.pstr(params)}'
 	}
 
-	return s + ' USING $e.using)'
+	return s + ' USING ${e.using})'
 }
 
 struct TrimExpr {
@@ -589,7 +589,7 @@ fn (e TrimExpr) str() string {
 }
 
 fn (e TrimExpr) pstr(params map[string]Value) string {
-	return 'TRIM($e.specification ${e.character.pstr(params)} FROM ${e.source.pstr(params)})'
+	return 'TRIM(${e.specification} ${e.character.pstr(params)} FROM ${e.source.pstr(params)})'
 }
 
 // UntypedNullExpr (not to be confused with NullExpr) represents an untyped
@@ -616,10 +616,10 @@ fn (e TruthExpr) str() string {
 
 fn (e TruthExpr) pstr(params map[string]Value) string {
 	if e.not {
-		return '${e.expr.pstr(params)} IS NOT $e.value.str()'
+		return '${e.expr.pstr(params)} IS NOT ${e.value.str()}'
 	}
 
-	return '${e.expr.pstr(params)} IS $e.value.str()'
+	return '${e.expr.pstr(params)} IS ${e.value.str()}'
 }
 
 struct CastExpr {
@@ -628,7 +628,7 @@ struct CastExpr {
 }
 
 fn (e CastExpr) pstr(params map[string]Value) string {
-	return 'CAST(${e.expr.pstr(params)} AS $e.target)'
+	return 'CAST(${e.expr.pstr(params)} AS ${e.target})'
 }
 
 struct CoalesceExpr {

--- a/vsql/bench.v
+++ b/vsql/bench.v
@@ -37,18 +37,18 @@ pub fn (mut b Benchmark) start() ! {
 
 	mut t := start_timer()
 	for aid in 1 .. b.account_rows + 1 {
-		b.conn.query('INSERT INTO accounts (aid, abalance) VALUES ($aid, 0)')!
+		b.conn.query('INSERT INTO accounts (aid, abalance) VALUES (${aid}, 0)')!
 	}
 	b.print_stat('INSERT', b.account_rows, 'rows', t.elapsed())
 
 	b.conn.query('CREATE TABLE tellers ( tid INT, tbalance INT, PRIMARY KEY ( tid ) ) ')!
 	for tid in 1 .. b.teller_rows + 1 {
-		b.conn.query('INSERT INTO tellers (tid, tbalance) VALUES ($tid, 0)')!
+		b.conn.query('INSERT INTO tellers (tid, tbalance) VALUES (${tid}, 0)')!
 	}
 
 	b.conn.query('CREATE TABLE branches ( bid INT, bbalance INT, PRIMARY KEY ( bid ) ) ')!
 	for bid in 1 .. b.branch_rows + 1 {
-		b.conn.query('INSERT INTO branches (bid, bbalance) VALUES ($bid, 0)')!
+		b.conn.query('INSERT INTO branches (bid, bbalance) VALUES (${bid}, 0)')!
 	}
 
 	// TODO(elliotchance): This should have a PRIMARY KEY when we support
@@ -75,7 +75,7 @@ pub fn (mut b Benchmark) start() ! {
 }
 
 fn (mut b Benchmark) print_stat(name string, n int, unit string, elapsed time.Duration) {
-	println('$name: $n $unit in ${elapsed.seconds():.3f} (${n / elapsed.seconds():.3f} $unit/s)')
+	println('${name}: ${n} ${unit} in ${elapsed.seconds():.3f} (${n / elapsed.seconds():.3f} ${unit}/s)')
 }
 
 fn (mut b Benchmark) run_transaction() ! {
@@ -86,13 +86,13 @@ fn (mut b Benchmark) run_transaction() ! {
 
 	b.conn.query('START TRANSACTION')!
 
-	b.conn.query('UPDATE accounts SET abalance = abalance + $delta WHERE aid = $aid')!
-	b.conn.query('SELECT abalance FROM accounts WHERE aid = $aid')!
-	b.conn.query('UPDATE tellers SET tbalance = tbalance + $delta WHERE tid = $tid')!
-	b.conn.query('UPDATE branches SET bbalance = bbalance + $delta WHERE bid = $bid')!
+	b.conn.query('UPDATE accounts SET abalance = abalance + ${delta} WHERE aid = ${aid}')!
+	b.conn.query('SELECT abalance FROM accounts WHERE aid = ${aid}')!
+	b.conn.query('UPDATE tellers SET tbalance = tbalance + ${delta} WHERE tid = ${tid}')!
+	b.conn.query('UPDATE branches SET bbalance = bbalance + ${delta} WHERE bid = ${bid}')!
 
 	// TODO(elliotchance): Should use CURRENT_TIMESTAMP once supported.
-	b.conn.query('INSERT INTO history (tid, bid, aid, delta, mtime) VALUES ($tid, $bid, $aid, $delta, \'$time.now()\')')!
+	b.conn.query('INSERT INTO history (tid, bid, aid, delta, mtime) VALUES (${tid}, ${bid}, ${aid}, ${delta}, \'${time.now()}\')')!
 
 	b.conn.query('COMMIT')!
 }

--- a/vsql/btree.v
+++ b/vsql/btree.v
@@ -25,7 +25,7 @@ module vsql
 struct Btree {
 	page_size int
 mut:
-	pager Pager
+	pager Pager = new_memory_pager()
 }
 
 fn new_btree(pager Pager, page_size int) &Btree {

--- a/vsql/btree_test.v
+++ b/vsql/btree_test.v
@@ -97,16 +97,16 @@ fn run_btree_test(mut pager Pager, size int, object_size int, page_size int, ran
 }
 
 fn visualize(mut p Pager) ! {
-	println('\n=== VISUALIZE (root = $p.root_page()) ===')
+	println('\n=== VISUALIZE (root = ${p.root_page()}) ===')
 	for i := 0; i < p.total_pages(); i++ {
 		page := p.fetch_page(i)!
 
 		match page.kind {
 			kind_leaf {
-				println('$i (leaf, $page.used b used): ${strkeys(page)}')
+				println('${i} (leaf, ${page.used} b used): ${strkeys(page)}')
 			}
 			kind_not_leaf {
-				println('$i (non-leaf, $page.used b used): ${strobjects(page)}')
+				println('${i} (non-leaf, ${page.used} b used): ${strobjects(page)}')
 			}
 			else {
 				panic(page.kind)
@@ -116,7 +116,7 @@ fn visualize(mut p Pager) ! {
 
 	leaf_objects, non_leaf_objects := count(mut p)!
 
-	println('total: $leaf_objects leaf objects + $non_leaf_objects non-leaf objects\n')
+	println('total: ${leaf_objects} leaf objects + ${non_leaf_objects} non-leaf objects\n')
 }
 
 // Validate ensures that the tree is valid.
@@ -163,7 +163,7 @@ fn validate_page(mut p Pager, page_number int) !([]u8, []u8, int) {
 			// min and max have already been verified in the subpage, but the
 			// min has to equal what our pointer says.
 			if compare_bytes(smallest, object.key) != 0 {
-				panic('$object.key.bytestr() in page $page_number points to $object_value, but child page has head $smallest.bytestr()')
+				panic('${object.key.bytestr()} in page ${page_number} points to ${object_value}, but child page has head ${smallest.bytestr()}')
 			}
 		}
 	} else {
@@ -219,7 +219,7 @@ fn strobjects(p Page) []string {
 	mut keys := []string{}
 	for object in p.objects() {
 		mut buf := new_bytes(object.value)
-		keys << '$object.key.bytestr():$buf.read_i32()'
+		keys << '${object.key.bytestr()}:${buf.read_i32()}'
 	}
 
 	return keys

--- a/vsql/btree_test.v
+++ b/vsql/btree_test.v
@@ -10,7 +10,7 @@ import rand.config
 // Note: When making changes to the btree (or anything that might affect it).
 // Please pick a higher value here for more exhustive testing. Use at least 10
 // (ideally 100) before the final diff.
-const times = 1
+const times = os.getenv_opt('TIMES') or { '1' }.int()
 
 fn test_btree_test() ! {
 	// This test runs on different pagers (file vs memory), blob sizes (below)

--- a/vsql/connection.v
+++ b/vsql/connection.v
@@ -336,7 +336,7 @@ pub mut:
 	// encouraged to do so.
 	//
 	// snippet: v.ConnectionOptions.query_cache
-	query_cache &QueryCache
+	query_cache &QueryCache = unsafe { nil }
 	// Warning: This only works for :memory: databases. Configuring it for
 	// file-based databases will either be ignored or causes crashes.
 	//
@@ -363,7 +363,7 @@ pub mut:
 	// RwMutex that belongs to each file - such as from a map.
 	//
 	// snippet: v.ConnectionOptions.mutex
-	mutex &sync.RwMutex
+	mutex &sync.RwMutex = unsafe { nil }
 	// now allows you to override the wall clock that is used. The Time must be
 	// in UTC with a separate offset for the current local timezone (in positive
 	// or negative minutes).

--- a/vsql/connection.v
+++ b/vsql/connection.v
@@ -268,7 +268,7 @@ pub fn (mut c Connection) register_virtual_table(create_table string, data Virtu
 				return sqlstate_3f000(parts[0]) // scheme does not exist
 			}
 		} else {
-			table_name = 'PUBLIC.$table_name'
+			table_name = 'PUBLIC.${table_name}'
 		}
 
 		c.virtual_tables[table_name] = VirtualTable{

--- a/vsql/connection_test.v
+++ b/vsql/connection_test.v
@@ -22,15 +22,15 @@ fn test_concurrent_writes() ! {
 
 	mut waits := []thread{}
 	for i in 0 .. 10 {
-		waits << go fn (file_name string, verbose bool, i int, options ConnectionOptions) {
+		waits << spawn fn (file_name string, verbose bool, i int, options ConnectionOptions) {
 			mut db := open_database(file_name, options) or { panic(err) }
 			for j in 0 .. 100 {
 				if verbose {
-					println('${i}.$j: INSERT start')
+					println('${i}.${j}: INSERT start')
 				}
 				db.query('INSERT INTO foo (x) VALUES (1)') or { panic(err) }
 				if verbose {
-					println('${i}.$j: INSERT done')
+					println('${i}.${j}: INSERT done')
 				}
 			}
 		}(file_name, verbose, i, options)

--- a/vsql/connection_test.v
+++ b/vsql/connection_test.v
@@ -3,10 +3,9 @@ module vsql
 import os
 import sync
 
-fn test_concurrent_writes() ! {
-	verbose_env := $env('VERBOSE')
-	verbose := verbose_env != ''
+const verbose = os.getenv('VERBOSE') != ''
 
+fn test_concurrent_writes() ! {
 	file_name := 'test_concurrent_writes.vsql'
 	if os.exists(file_name) {
 		os.rm(file_name) or { return err }
@@ -22,18 +21,18 @@ fn test_concurrent_writes() ! {
 
 	mut waits := []thread{}
 	for i in 0 .. 10 {
-		waits << spawn fn (file_name string, verbose bool, i int, options ConnectionOptions) {
+		waits << spawn fn (file_name string, i int, options ConnectionOptions) {
 			mut db := open_database(file_name, options) or { panic(err) }
 			for j in 0 .. 100 {
-				if verbose {
+				if vsql.verbose {
 					println('${i}.${j}: INSERT start')
 				}
 				db.query('INSERT INTO foo (x) VALUES (1)') or { panic(err) }
-				if verbose {
+				if vsql.verbose {
 					println('${i}.${j}: INSERT done')
 				}
 			}
-		}(file_name, verbose, i, options)
+		}(file_name, i, options)
 	}
 	waits.wait()
 

--- a/vsql/create_table.v
+++ b/vsql/create_table.v
@@ -25,7 +25,7 @@ fn execute_create_table(mut c Connection, stmt CreateTableStmt, elapsed_parse ti
 			return sqlstate_3f000(parts[0]) // scheme does not exist
 		}
 	} else {
-		table_name = 'PUBLIC.$table_name'
+		table_name = 'PUBLIC.${table_name}'
 	}
 
 	if table_name in c.storage.tables {
@@ -61,7 +61,7 @@ fn execute_create_table(mut c Connection, stmt CreateTableStmt, elapsed_parse ti
 										primary_key << column.name
 									}
 									else {
-										return sqlstate_42601('PRIMARY KEY does not support $e.typ')
+										return sqlstate_42601('PRIMARY KEY does not support ${e.typ}')
 									}
 								}
 
@@ -71,7 +71,7 @@ fn execute_create_table(mut c Connection, stmt CreateTableStmt, elapsed_parse ti
 					}
 
 					if !found {
-						return sqlstate_42601('unknown column $column.name in PRIMARY KEY')
+						return sqlstate_42601('unknown column ${column.name} in PRIMARY KEY')
 					}
 				}
 			}

--- a/vsql/delete.v
+++ b/vsql/delete.v
@@ -23,7 +23,7 @@ fn execute_delete(mut c Connection, stmt DeleteStmt, params map[string]Value, el
 			return sqlstate_3f000(parts[0]) // scheme does not exist
 		}
 	} else {
-		table_name = 'PUBLIC.$table_name'
+		table_name = 'PUBLIC.${table_name}'
 	}
 
 	mut plan := create_plan(stmt, params, c)!
@@ -38,5 +38,5 @@ fn execute_delete(mut c Connection, stmt DeleteStmt, params map[string]Value, el
 		c.storage.delete_row(table_name, mut row)!
 	}
 
-	return new_result_msg('DELETE $rows.len', elapsed_parse, t.elapsed())
+	return new_result_msg('DELETE ${rows.len}', elapsed_parse, t.elapsed())
 }

--- a/vsql/drop_table.v
+++ b/vsql/drop_table.v
@@ -23,7 +23,7 @@ fn execute_drop_table(mut c Connection, stmt DropTableStmt, elapsed_parse time.D
 			return sqlstate_3f000(parts[0]) // scheme does not exist
 		}
 	} else {
-		table_name = 'PUBLIC.$table_name'
+		table_name = 'PUBLIC.${table_name}'
 	}
 
 	if table_name !in c.storage.tables {

--- a/vsql/earley.v
+++ b/vsql/earley.v
@@ -73,7 +73,7 @@ fn new_earley_state(name string, production &EarleyProduction, dot_index int, st
 }
 
 fn (state &EarleyState) index() string {
-	return '$state.name $state.production.index() $state.dot_index $state.start_column'
+	return '${state.name} ${state.production.index()} ${state.dot_index} ${state.start_column}'
 }
 
 fn (state &EarleyState) str() string {
@@ -84,7 +84,7 @@ fn (state &EarleyState) str() string {
 
 	terms.insert(state.dot_index, '$')
 
-	return '$state.name -> ${terms.join(' ')} [$state.start_column-$state.end_column]'
+	return '${state.name} -> ${terms.join(' ')} [${state.start_column}-${state.end_column}]'
 }
 
 fn (state &EarleyState) eq(other &EarleyState) bool {
@@ -144,11 +144,11 @@ fn new_earley_column(index int, token string, value string) &EarleyColumn {
 }
 
 fn (col &EarleyColumn) str() string {
-	return '$col.index'
+	return '${col.index}'
 }
 
 fn (col &EarleyColumn) repr() string {
-	return '$col.token:$col.value'
+	return '${col.token}:${col.value}'
 }
 
 fn (mut col EarleyColumn) add(mut state EarleyState) bool {
@@ -164,7 +164,7 @@ fn (mut col EarleyColumn) add(mut state EarleyState) bool {
 }
 
 fn (col &EarleyColumn) print() {
-	println('[$col.index] $col.token')
+	println('[${col.index}] ${col.token}')
 	println(strings.repeat_string('=', 35))
 	for s in col.states {
 		println(s.str())

--- a/vsql/eval.v
+++ b/vsql/eval.v
@@ -523,8 +523,8 @@ fn eval_binary(conn Connection, data Row, e BinaryExpr, params map[string]Value)
 
 	key := '${left.typ.typ} ${e.op} ${right.typ.typ}'
 	if fnc := conn.binary_operators[key] {
-		op_fn:=fnc as BinaryOperatorFunc
-		return op_fn(conn, left, right) 
+		op_fn := fnc as BinaryOperatorFunc
+		return op_fn(conn, left, right)
 	}
 
 	return sqlstate_42883('operator does not exist: ${left.typ} ${e.op} ${right.typ}')
@@ -534,9 +534,9 @@ fn eval_unary(conn &Connection, data Row, e UnaryExpr, params map[string]Value) 
 	value := eval_as_value(conn, data, e.expr, params)!
 
 	key := '${e.op} ${value.typ.typ}'
-	if fnc:= conn.unary_operators[key] {
-		unary_fn:=fnc as UnaryOperatorFunc
-		return unary_fn(conn, value)! 
+	if fnc := conn.unary_operators[key] {
+		unary_fn := fnc as UnaryOperatorFunc
+		return unary_fn(conn, value)!
 	}
 
 	return sqlstate_42883('operator does not exist: ${key}')

--- a/vsql/expr.v
+++ b/vsql/expr.v
@@ -103,7 +103,7 @@ fn expr_is_agg(conn &Connection, e Expr, row Row, params map[string]Value) !bool
 }
 
 fn nested_agg_unsupported(e Expr) !bool {
-	return sqlstate_42601('nested aggregate functions are not supported: $e.str()')
+	return sqlstate_42601('nested aggregate functions are not supported: ${e.str()}')
 }
 
 fn resolve_identifiers_exprs(exprs []Expr, tables map[string]Table) ![]Expr {
@@ -140,12 +140,12 @@ fn resolve_identifiers(e Expr, tables map[string]Table) !Expr {
 			}
 
 			if parts.len == 2 {
-				return new_identifier('PUBLIC.$e.name')
+				return new_identifier('PUBLIC.${e.name}')
 			}
 
 			for _, table in tables {
 				if (table.column(e.name) or { Column{} }).name == e.name {
-					return new_identifier('${table.name}.$e')
+					return new_identifier('${table.name}.${e}')
 				}
 			}
 

--- a/vsql/flock_windows.c.v
+++ b/vsql/flock_windows.c.v
@@ -10,12 +10,12 @@ import os.filelock
 
 fn flock_lock_exclusive(file os.File, path string) ! {
 	mut f := filelock.new('${path}.lock')
-	f.acquire() or { return error('cannot acquire lock: $err') }
+	f.acquire() or { return error('cannot acquire lock: ${err}') }
 }
 
 fn flock_lock_shared(file os.File, path string) ! {
 	mut f := filelock.new('${path}.lock')
-	f.acquire() or { return error('cannot acquire lock: $err') }
+	f.acquire() or { return error('cannot acquire lock: ${err}') }
 }
 
 fn flock_unlock_exclusive(file os.File, path string) {

--- a/vsql/group.v
+++ b/vsql/group.v
@@ -52,7 +52,7 @@ fn new_group_operation(select_exprs []DerivedColumn, group_exprs []Expr, params 
 }
 
 fn (o &GroupOperation) str() string {
-	return 'GROUP BY ($o.columns())'
+	return 'GROUP BY (${o.columns()})'
 }
 
 fn (o &GroupOperation) columns() Columns {
@@ -112,7 +112,7 @@ fn (o &GroupOperation) execute(rows []Row) ![]Row {
 						set[0].data[key] = new_integer_value(set.len)
 					}
 					else {
-						return sqlstate_42601('invalid set function: $expr.expr')
+						return sqlstate_42601('invalid set function: ${expr.expr}')
 					}
 				}
 			}

--- a/vsql/header.v
+++ b/vsql/header.v
@@ -62,26 +62,26 @@ fn new_header(page_size int) Header {
 fn init_database_file(path string, page_size int) ! {
 	header := new_header(page_size)
 
-	mut tmpf := os.create(path) or { return error('cannot create file $path: $err') }
+	mut tmpf := os.create(path) or { return error('cannot create file ${path}: ${err}') }
 	write_header(mut tmpf, header)!
 	tmpf.close()
 }
 
 fn read_header(mut file os.File) !Header {
-	file.seek(0, .start) or { return error('unable seek start: $err') }
+	file.seek(0, .start) or { return error('unable seek start: ${err}') }
 
-	header := file.read_raw<Header>() or { return error('unable to read raw header: $err') }
+	header := file.read_raw[Header]() or { return error('unable to read raw header: ${err}') }
 
 	// Check file version compatibility.
 	if header.version != vsql.current_version {
-		return error('need version $vsql.current_version but database is $header.version')
+		return error('need version ${vsql.current_version} but database is ${header.version}')
 	}
 
 	return header
 }
 
 fn write_header(mut file os.File, header Header) ! {
-	file.seek(0, .start) or { return error('unable seek start: $err') }
+	file.seek(0, .start) or { return error('unable seek start: ${err}') }
 
-	file.write_raw(header) or { return error('unable to write raw header: $err') }
+	file.write_raw(header) or { return error('unable to write raw header: ${err}') }
 }

--- a/vsql/insert.v
+++ b/vsql/insert.v
@@ -33,7 +33,7 @@ fn execute_insert(mut c Connection, stmt InsertStmt, params map[string]Value, el
 			return sqlstate_3f000(parts[0]) // scheme does not exist
 		}
 	} else {
-		table_name = 'PUBLIC.$table_name'
+		table_name = 'PUBLIC.${table_name}'
 	}
 
 	if table_name !in c.storage.tables {
@@ -46,10 +46,10 @@ fn execute_insert(mut c Connection, stmt InsertStmt, params map[string]Value, el
 		table_column := table.column(column_name)!
 		raw_value := eval_as_nullable_value(c, table_column.typ.typ, Row{}, stmt.values[i],
 			params)!
-		value := cast(c, 'for column $column_name', raw_value, table_column.typ)!
+		value := cast(c, 'for column ${column_name}', raw_value, table_column.typ)!
 
 		if value.is_null && table_column.not_null {
-			return sqlstate_23502('column $column_name')
+			return sqlstate_23502('column ${column_name}')
 		}
 
 		row[column_name] = value
@@ -62,7 +62,7 @@ fn execute_insert(mut c Connection, stmt InsertStmt, params map[string]Value, el
 		}
 
 		if col.not_null {
-			return sqlstate_23502('column $col.name')
+			return sqlstate_23502('column ${col.name}')
 		}
 
 		row[col.name] = new_null_value(col.typ.typ)

--- a/vsql/join.v
+++ b/vsql/join.v
@@ -19,7 +19,7 @@ fn new_join_operation(left_columns Columns, join_type string, right_columns Colu
 }
 
 fn (o &JoinOperation) str() string {
-	return '$o.join_type JOIN ON $o.specification ($o.columns())'
+	return '${o.join_type} JOIN ON ${o.specification} (${o.columns()})'
 }
 
 fn (o &JoinOperation) columns() Columns {

--- a/vsql/lexer.v
+++ b/vsql/lexer.v
@@ -80,7 +80,7 @@ fn tokenize(sql string) []Token {
 				i++
 			}
 			i++
-			tokens << Token{.literal_identifier, '"$word"'}
+			tokens << Token{.literal_identifier, '"${word}"'}
 			continue
 		}
 

--- a/vsql/operators.v
+++ b/vsql/operators.v
@@ -31,34 +31,34 @@ fn register_binary_operators(mut conn Connection) {
 
 	for typ1 in int_types {
 		for typ2 in int_types {
-			conn.binary_operators['$typ1 = $typ2'] = binary_int_equal_int
-			conn.binary_operators['$typ1 <> $typ2'] = binary_int_not_equal_int
-			conn.binary_operators['$typ1 < $typ2'] = binary_int_less_int
-			conn.binary_operators['$typ1 > $typ2'] = binary_int_greater_int
-			conn.binary_operators['$typ1 <= $typ2'] = binary_int_less_equal_int
-			conn.binary_operators['$typ1 >= $typ2'] = binary_int_greater_equal_int
+			conn.binary_operators['${typ1} = ${typ2}'] = binary_int_equal_int
+			conn.binary_operators['${typ1} <> ${typ2}'] = binary_int_not_equal_int
+			conn.binary_operators['${typ1} < ${typ2}'] = binary_int_less_int
+			conn.binary_operators['${typ1} > ${typ2}'] = binary_int_greater_int
+			conn.binary_operators['${typ1} <= ${typ2}'] = binary_int_less_equal_int
+			conn.binary_operators['${typ1} >= ${typ2}'] = binary_int_greater_equal_int
 		}
 	}
 
 	for typ1 in float_types {
 		for typ2 in float_types {
-			conn.binary_operators['$typ1 = $typ2'] = binary_float_equal_float
-			conn.binary_operators['$typ1 <> $typ2'] = binary_float_not_equal_float
-			conn.binary_operators['$typ1 < $typ2'] = binary_float_less_float
-			conn.binary_operators['$typ1 > $typ2'] = binary_float_greater_float
-			conn.binary_operators['$typ1 <= $typ2'] = binary_float_less_equal_float
-			conn.binary_operators['$typ1 >= $typ2'] = binary_float_greater_equal_float
+			conn.binary_operators['${typ1} = ${typ2}'] = binary_float_equal_float
+			conn.binary_operators['${typ1} <> ${typ2}'] = binary_float_not_equal_float
+			conn.binary_operators['${typ1} < ${typ2}'] = binary_float_less_float
+			conn.binary_operators['${typ1} > ${typ2}'] = binary_float_greater_float
+			conn.binary_operators['${typ1} <= ${typ2}'] = binary_float_less_equal_float
+			conn.binary_operators['${typ1} >= ${typ2}'] = binary_float_greater_equal_float
 		}
 	}
 
 	for typ1 in text_types {
 		for typ2 in text_types {
-			conn.binary_operators['$typ1 = $typ2'] = binary_string_equal_string
-			conn.binary_operators['$typ1 <> $typ2'] = binary_string_not_equal_string
-			conn.binary_operators['$typ1 < $typ2'] = binary_string_less_string
-			conn.binary_operators['$typ1 > $typ2'] = binary_string_greater_string
-			conn.binary_operators['$typ1 <= $typ2'] = binary_string_less_equal_string
-			conn.binary_operators['$typ1 >= $typ2'] = binary_string_greater_equal_string
+			conn.binary_operators['${typ1} = ${typ2}'] = binary_string_equal_string
+			conn.binary_operators['${typ1} <> ${typ2}'] = binary_string_not_equal_string
+			conn.binary_operators['${typ1} < ${typ2}'] = binary_string_less_string
+			conn.binary_operators['${typ1} > ${typ2}'] = binary_string_greater_string
+			conn.binary_operators['${typ1} <= ${typ2}'] = binary_string_less_equal_string
+			conn.binary_operators['${typ1} >= ${typ2}'] = binary_string_greater_equal_string
 		}
 	}
 

--- a/vsql/page.v
+++ b/vsql/page.v
@@ -195,7 +195,7 @@ fn (p Page) versions(key []u8, objects []PageObject) []int {
 // should be interpreted by the client as a try again. See description below.
 fn (mut p Page) add(obj PageObject) ! {
 	if p.used + obj.length() > p.page_size() {
-		panic('page cannot fit object of $obj.length() b in page using $p.used b')
+		panic('page cannot fit object of ${obj.length()} b in page using ${p.used} b')
 	}
 
 	// If there are two versions, there must be one version that is

--- a/vsql/pager.v
+++ b/vsql/pager.v
@@ -80,9 +80,9 @@ mut:
 // new_file_pager requires that the path already exists and has already been
 // initialized as a new database.
 fn new_file_pager(mut file os.File, page_size int, root_page int) !&FilePager {
-	file.seek(0, .end) or { return error('unable seek end: $err') }
+	file.seek(0, .end) or { return error('unable seek end: ${err}') }
 
-	file_len := file.tell() or { return error('unable to get file length: $err') }
+	file_len := file.tell() or { return error('unable to get file length: ${err}') }
 
 	return &FilePager{
 		file: file
@@ -98,11 +98,11 @@ fn (mut p FilePager) fetch_page(page_number int) !Page {
 	// The first page is reserved for header information. We do not include this
 	// in the pages.
 	p.file.seek(int(sizeof(Header)) + (p.page_size * page_number), .start) or {
-		return error('unable to seek: $err')
+		return error('unable to seek: ${err}')
 	}
 
 	mut buf := []u8{len: p.page_size}
-	p.file.read(mut buf) or { return error('unable to read from file: $err') }
+	p.file.read(mut buf) or { return error('unable to read from file: ${err}') }
 
 	mut b := new_bytes(buf)
 
@@ -117,7 +117,7 @@ fn (mut p FilePager) store_page(page_number int, page Page) ! {
 	// The first page is reserved for header information. We do not include this
 	// in the pages.
 	p.file.seek(int(sizeof(Header)) + (p.page_size * page_number), .start) or {
-		return error('unable to seek: $err')
+		return error('unable to seek: ${err}')
 	}
 
 	mut b := new_empty_bytes()
@@ -125,7 +125,7 @@ fn (mut p FilePager) store_page(page_number int, page Page) ! {
 	b.write_u16(page.used)
 	b.write_u8s(page.data)
 
-	p.file.write(b.bytes()) or { return error('unable to write to file: $err') }
+	p.file.write(b.bytes()) or { return error('unable to write to file: ${err}') }
 }
 
 fn (mut p FilePager) total_pages() int {
@@ -135,7 +135,7 @@ fn (mut p FilePager) total_pages() int {
 fn (mut p FilePager) append_page(page Page) !int {
 	// The first page is reserved for header information. We do not include this
 	// in the pages.
-	p.store_page(p.total_pages, page) or { return error('unable to store page: $err') }
+	p.store_page(p.total_pages, page) or { return error('unable to store page: ${err}') }
 	p.total_pages++
 
 	return p.total_pages - 1

--- a/vsql/parse.v
+++ b/vsql/parse.v
@@ -244,14 +244,14 @@ fn parse_value(v Value) !Value {
 }
 
 fn parse_exact_numeric_literal1(a string, b string) !Value {
-	mut v := new_double_precision_value('${a}.$b'.f64())
+	mut v := new_double_precision_value('${a}.${b}'.f64())
 	v.is_coercible = true
 
 	return v
 }
 
 fn parse_exact_numeric_literal2(a string) !Value {
-	mut v := new_double_precision_value('0.$a'.f64())
+	mut v := new_double_precision_value('0.${a}'.f64())
 	v.is_coercible = true
 
 	return v
@@ -766,7 +766,7 @@ fn parse_schema_definition(schema_name Identifier) !Stmt {
 }
 
 fn parse_local_or_schema_qualified_name2(schema_name Identifier, table_name Identifier) !Identifier {
-	return new_identifier('${schema_name}.$table_name')
+	return new_identifier('${schema_name}.${table_name}')
 }
 
 fn parse_drop_schema_statement(schema_name Identifier, behavior string) !Stmt {

--- a/vsql/pg.v
+++ b/vsql/pg.v
@@ -64,9 +64,9 @@ fn (mut c PGConn) write_command_complete(result Result) ! {
 	c.write_byte(`C`)!
 
 	// TODO(elliotchance): This is a hack that will probably cause issues.
-	mut tag := 'SELECT $result.rows.len'
+	mut tag := 'SELECT ${result.rows.len}'
 	if result.columns.len == 1 && result.columns[0].name == 'msg' && result.rows.len == 1 {
-		tag = result.rows[0].get_string('msg') or { '$err' }
+		tag = result.rows[0].get_string('msg') or { '${err}' }
 	}
 
 	mut msg_len := 4 // self
@@ -126,11 +126,11 @@ fn (mut c PGConn) read_query() !string {
 }
 
 fn (mut c PGConn) write_byte(b u8) ! {
-	c.conn.write([b]) or { return error('cannot write to tcp connection: $err') }
+	c.conn.write([b]) or { return error('cannot write to tcp connection: ${err}') }
 }
 
 fn (mut c PGConn) write_bytes(b []u8) ! {
-	c.conn.write(b) or { return error('cannot write to tcp connection: $err') }
+	c.conn.write(b) or { return error('cannot write to tcp connection: ${err}') }
 }
 
 fn (mut c PGConn) write_row_description(result Result) ! {
@@ -163,7 +163,7 @@ fn (mut c PGConn) write_data_row(columns Columns, row Row) ! {
 	mut msg_len := 4 // self
 	msg_len += 2 // cols
 	for column in columns {
-		v := row.get_string(column.name) or { '$err' }
+		v := row.get_string(column.name) or { '${err}' }
 		msg_len += 4 + v.len
 	}
 
@@ -171,7 +171,7 @@ fn (mut c PGConn) write_data_row(columns Columns, row Row) ! {
 	c.write_int16(i16(columns.len))!
 
 	for column in columns {
-		v := row.get_string(column.name) or { '$err' }
+		v := row.get_string(column.name) or { '${err}' }
 		c.write_int32(v.len)!
 		c.write_bytes(v.bytes())!
 	}
@@ -199,13 +199,13 @@ fn (mut c PGConn) read_int32() !int {
 fn (mut c PGConn) write_int16(x i16) ! {
 	mut bytes := []u8{len: 2}
 	binary.big_endian_put_u16(mut bytes, u16(x))
-	c.conn.write(bytes) or { return error('cannot write to tcp connection: $err') }
+	c.conn.write(bytes) or { return error('cannot write to tcp connection: ${err}') }
 }
 
 fn (mut c PGConn) write_int32(x int) ! {
 	mut bytes := []u8{len: 4}
 	binary.big_endian_put_u32(mut bytes, u32(x))
-	c.conn.write(bytes) or { return error('cannot write to tcp connection: $err') }
+	c.conn.write(bytes) or { return error('cannot write to tcp connection: ${err}') }
 }
 
 fn (mut c PGConn) read_string() !(string, int) {
@@ -230,7 +230,7 @@ fn (mut c PGConn) write_string(s string) ! {
 }
 
 fn (mut c PGConn) close() ! {
-	c.conn.close() or { return error('cannot close connection: $err') }
+	c.conn.close() or { return error('cannot close connection: ${err}') }
 }
 
 fn register_pg_functions(mut db Connection) ! {

--- a/vsql/planner.v
+++ b/vsql/planner.v
@@ -32,7 +32,7 @@ fn create_plan(stmt Stmt, params map[string]Value, c &Connection) !Plan {
 		DeleteStmt { return create_delete_plan(stmt, params, c) }
 		QueryExpression { return create_query_expression_plan(stmt, params, c, Correlation{}) }
 		UpdateStmt { return create_update_plan(stmt, params, c) }
-		else { return error('cannot create plan for $stmt') }
+		else { return error('cannot create plan for ${stmt}') }
 	}
 }
 
@@ -109,7 +109,7 @@ fn create_select_plan_without_join(body SelectStmt, from_clause TablePrimary, of
 					return sqlstate_3f000(parts[0]) // scheme does not exist
 				}
 			} else {
-				table_name = 'PUBLIC.$table_name'
+				table_name = 'PUBLIC.${table_name}'
 			}
 
 			if allow_virtual && table_name in c.virtual_tables {

--- a/vsql/query_cache.v
+++ b/vsql/query_cache.v
@@ -82,19 +82,19 @@ fn (q QueryCache) prepare_stmt(tokens []Token) (string, map[string]Value, []Toke
 						v = new_bigint_value(token.value.i64())
 					}
 					v.is_coercible = true
-					params['P$i'] = v
+					params['P${i}'] = v
 
-					key += ':P$i '
+					key += ':P${i} '
 					new_tokens << Token{.colon, ':'}
-					new_tokens << Token{.literal_identifier, 'P$i'}
+					new_tokens << Token{.literal_identifier, 'P${i}'}
 					i++
 					continue
 				}
 				.literal_string {
-					key += ':P$i '
-					params['P$i'] = new_varchar_value(token.value, 0)
+					key += ':P${i} '
+					params['P${i}'] = new_varchar_value(token.value, 0)
 					new_tokens << Token{.colon, ':'}
-					new_tokens << Token{.literal_identifier, 'P$i'}
+					new_tokens << Token{.literal_identifier, 'P${i}'}
 					i++
 					continue
 				}

--- a/vsql/row.v
+++ b/vsql/row.v
@@ -45,7 +45,7 @@ pub fn (r Row) get_f64(name string) !f64 {
 		return value.f64_value
 	}
 
-	return error("cannot use get_f64('$name') when type is $value.typ")
+	return error("cannot use get_f64('${name}') when type is ${value.typ}")
 }
 
 // get_int will only work for columns that are integers (SMALLINT, INTEGER or
@@ -58,7 +58,7 @@ pub fn (r Row) get_int(name string) !int {
 		return int(value.int_value)
 	}
 
-	return error("cannot use get_int('$name') when type is $value.typ")
+	return error("cannot use get_int('${name}') when type is ${value.typ}")
 }
 
 // get_string is the most flexible getter and will try to coerce the value
@@ -87,7 +87,7 @@ pub fn (r Row) get_bool(name string) !Boolean {
 			return value.bool_value
 		}
 		else {
-			return error("cannot use get_bool('$name') when type is $value.typ")
+			return error("cannot use get_bool('${name}') when type is ${value.typ}")
 		}
 	}
 }
@@ -101,11 +101,11 @@ pub fn (r Row) get(name string) !Value {
 		// Be helpful and look for silly mistakes.
 		for n, _ in r.data {
 			if n.to_upper() == name.to_upper() {
-				return error('no such column $name, did you mean $n?')
+				return error('no such column ${name}, did you mean ${n}?')
 			}
 		}
 
-		return error('no such column $name')
+		return error('no such column ${name}')
 	}
 }
 
@@ -120,7 +120,7 @@ fn new_empty_row(columns Columns, table_name string) Row {
 		if table_name == '' {
 			r.data[col.name] = v
 		} else {
-			r.data['${table_name}.$col.name'] = v
+			r.data['${table_name}.${col.name}'] = v
 		}
 	}
 
@@ -168,7 +168,7 @@ fn new_empty_table_row(tables map[string]Table) Row {
 	mut r := Row{}
 	for _, table in tables {
 		for col in table.columns {
-			r.data['${table.name}.$col.name'] = new_empty_value(col.typ)
+			r.data['${table.name}.${col.name}'] = new_empty_value(col.typ)
 		}
 	}
 
@@ -271,7 +271,7 @@ fn new_row_from_bytes(t Table, data []u8, tid int, table_name string) Row {
 		if !v.is_null || v.typ.typ == .is_boolean {
 			match col.typ.typ {
 				.is_boolean {
-					unsafe{
+					unsafe {
 						v.bool_value = Boolean(buf.read_u8())
 						if v.bool_value == .is_unknown {
 							v.is_null = true
@@ -322,7 +322,7 @@ fn new_row_from_bytes(t Table, data []u8, tid int, table_name string) Row {
 		if table_name == '' {
 			row[col.name] = v
 		} else {
-			row['${table_name}.$col.name'] = v
+			row['${table_name}.${col.name}'] = v
 		}
 	}
 
@@ -347,7 +347,7 @@ fn (mut r Row) object_key(t Table) ![]u8 {
 					pk.write_i16(i16(r.data[col_name].int_value))
 				}
 				else {
-					return error('cannot use $col.typ.str() in PRIMARY KEY')
+					return error('cannot use ${col.typ.str()} in PRIMARY KEY')
 				}
 			}
 		}

--- a/vsql/schema.v
+++ b/vsql/schema.v
@@ -34,5 +34,5 @@ fn new_schema_from_bytes(data []u8, tid int) Schema {
 //
 // snippet: v.Schema.str
 fn (s Schema) str() string {
-	return 'CREATE SCHEMA $s.name;'
+	return 'CREATE SCHEMA ${s.name};'
 }

--- a/vsql/server.v
+++ b/vsql/server.v
@@ -24,7 +24,7 @@ pub fn new_server(options ServerOptions) Server {
 }
 
 pub fn (mut s Server) start() ! {
-	s.db = open(s.options.db_file) or { panic('cannot open database: $err') }
+	s.db = open(s.options.db_file) or { panic('cannot open database: ${err}') }
 
 	// There are multiple compatibility changes we need to make during the
 	// connection. A missing "FROM" clause is valid in PostgreSQL, but it's not
@@ -45,17 +45,17 @@ pub fn (mut s Server) start() ! {
 	register_pg_functions(mut s.db)!
 	register_pg_virtual_tables(mut s.db)!
 
-	mut listener := net.listen_tcp(.ip6, ':$s.options.port') or {
-		return error('cannot listen on :$s.options.port: $err')
+	mut listener := net.listen_tcp(.ip6, ':${s.options.port}') or {
+		return error('cannot listen on :${s.options.port}: ${err}')
 	}
-	println('ready on 127.0.0.1:$s.options.port')
+	println('ready on 127.0.0.1:${s.options.port}')
 
 	mut client_id := 0
 	for {
 		client_id++
 
 		mut conn := listener.accept() or {
-			s.log('$err')
+			s.log('${err}')
 			continue
 		}
 
@@ -91,19 +91,19 @@ fn (mut s Server) handle_conn(mut c net.TcpConn) ! {
 					query = query.trim('; ') + ' FROM singlerow;'
 				}
 
-				s.log('query: $query')
+				s.log('query: ${query}')
 
 				mut did_error := false
 				result := s.db.query(query) or {
 					did_error = true
-					s.log('error: $err')
+					s.log('error: ${err}')
 
 					conn.write_error_result(err)!
 					new_result([]Column{}, []Row{}, 0, 0) // not used
 				}
 
 				if !did_error {
-					s.log('response: $result')
+					s.log('response: ${result}')
 					conn.write_result(result)!
 				}
 
@@ -115,7 +115,7 @@ fn (mut s Server) handle_conn(mut c net.TcpConn) ! {
 				break
 			}
 			else {
-				return error('unknown message: $msg_type.str()')
+				return error('unknown message: ${msg_type.str()}')
 			}
 		}
 	}

--- a/vsql/sql_test.v
+++ b/vsql/sql_test.v
@@ -69,19 +69,19 @@ fn get_tests() ![]SQLTest {
 						params[parts[1]] = new_double_precision_value(parts[2].f64())
 					}
 				} else {
-					panic('bad directive: "$contents"')
+					panic('bad directive: "${contents}"')
 				}
 			} else if line.starts_with('-- ') {
 				expected << line[3..]
 			} else {
 				if in_setup {
-					setup_stmt += '\n$line'
+					setup_stmt += '\n${line}'
 					if line.ends_with(';') {
 						setup << setup_stmt
 						setup_stmt = ''
 					}
 				} else {
-					stmt += '\n$line'
+					stmt += '\n${line}'
 					if line.ends_with(';') {
 						stmts << stmt
 						stmt = ''
@@ -112,16 +112,16 @@ fn test_all() ! {
 fn run_single_test(test SQLTest, query_cache &QueryCache, verbose bool, filter_line int) ! {
 	if filter_line != 0 && test.line_number != filter_line {
 		if verbose {
-			println('SKIP $test.file_name:$test.line_number\n')
+			println('SKIP ${test.file_name}:${test.line_number}\n')
 		}
 
 		return
 	}
 
 	if verbose {
-		println('BEGIN $test.file_name:$test.line_number')
+		println('BEGIN ${test.file_name}:${test.line_number}')
 		defer {
-			println('END $test.file_name:$test.line_number\n')
+			println('END ${test.file_name}:${test.line_number}\n')
 		}
 	}
 
@@ -156,7 +156,7 @@ fn run_single_test(test SQLTest, query_cache &QueryCache, verbose bool, filter_l
 
 	for stmt in test.setup {
 		if verbose {
-			println('  $stmt.trim_space()')
+			println('  ${stmt.trim_space()}')
 		}
 
 		mut prepared := db.prepare(stmt)!
@@ -179,18 +179,18 @@ fn run_single_test(test SQLTest, query_cache &QueryCache, verbose bool, filter_l
 		}
 
 		if verbose {
-			println('  $stmt.trim_space()')
+			println('  ${stmt.trim_space()}')
 		}
 
 		mut prepared := db.prepare(stmt) or {
-			actual += 'error ${sqlstate_from_int(err.code())}: $err.msg()\n'
+			actual += 'error ${sqlstate_from_int(err.code())}: ${err.msg()}\n'
 			continue
 		}
 		result := prepared.query(test.params) or {
 			if current_connection_name == '' {
-				actual += 'error ${sqlstate_from_int(err.code())}: $err.msg()\n'
+				actual += 'error ${sqlstate_from_int(err.code())}: ${err.msg()}\n'
 			} else {
-				actual += '$current_connection_name: error ${sqlstate_from_int(err.code())}: $err.msg()\n'
+				actual += '${current_connection_name}: error ${sqlstate_from_int(err.code())}: ${err.msg()}\n'
 			}
 
 			continue
@@ -200,17 +200,17 @@ fn run_single_test(test SQLTest, query_cache &QueryCache, verbose bool, filter_l
 			mut line := ''
 
 			if current_connection_name != '' {
-				line = '$current_connection_name: '
+				line = '${current_connection_name}: '
 			}
 
 			for col in result.columns {
-				line += '$col.name: ${row.get_string(col.name)!} '
+				line += '${col.name}: ${row.get_string(col.name)!} '
 			}
 			actual += line.trim_space() + '\n'
 		}
 	}
 
-	at := 'at $test.file_name:$test.line_number:\n'
+	at := 'at ${test.file_name}:${test.line_number}:\n'
 	mut expected := at + test.expected.trim_space()
 	actual_trim := at + actual.trim_space()
 

--- a/vsql/sqlstate.v
+++ b/vsql/sqlstate.v
@@ -90,7 +90,7 @@ struct SQLState22001 {
 fn sqlstate_22001(to Type) IError {
 	return SQLState22001{
 		code: sqlstate_to_int('22001')
-		msg: 'string data right truncation for $to'
+		msg: 'string data right truncation for ${to}'
 		to: to
 	}
 }
@@ -127,7 +127,7 @@ struct SQLState23502 {
 fn sqlstate_23502(msg string) IError {
 	return SQLState23502{
 		code: sqlstate_to_int('23502')
-		msg: 'violates non-null constraint: $msg'
+		msg: 'violates non-null constraint: ${msg}'
 	}
 }
 
@@ -141,7 +141,7 @@ pub:
 fn sqlstate_2bp01(object_name string) IError {
 	return SQLState2BP01{
 		code: sqlstate_to_int('2BP01')
-		msg: 'dependent objects still exist on $object_name'
+		msg: 'dependent objects still exist on ${object_name}'
 		object_name: object_name
 	}
 }
@@ -156,7 +156,7 @@ pub:
 fn sqlstate_3f000(schema_name string) IError {
 	return SQLState42P06{
 		code: sqlstate_to_int('3F000')
-		msg: 'invalid schema name: $schema_name'
+		msg: 'invalid schema name: ${schema_name}'
 		schema_name: schema_name
 	}
 }
@@ -169,7 +169,7 @@ struct SQLState42601 {
 fn sqlstate_42601(message string) IError {
 	return SQLState42601{
 		code: sqlstate_to_int('42601')
-		msg: 'syntax error: $message'
+		msg: 'syntax error: ${message}'
 	}
 }
 
@@ -183,7 +183,7 @@ pub:
 fn sqlstate_42703(column_name string) IError {
 	return SQLState42703{
 		code: sqlstate_to_int('42703')
-		msg: 'no such column: $column_name'
+		msg: 'no such column: ${column_name}'
 		column_name: column_name
 	}
 }
@@ -198,7 +198,7 @@ struct SQLState42804 {
 fn sqlstate_42804(msg string, expected string, actual string) IError {
 	return SQLState42804{
 		code: sqlstate_to_int('42804')
-		msg: 'data type mismatch $msg: expected $expected but got $actual'
+		msg: 'data type mismatch ${msg}: expected ${expected} but got ${actual}'
 		expected: expected
 		actual: actual
 	}
@@ -214,7 +214,7 @@ struct SQLState42846 {
 fn sqlstate_42846(from Type, to Type) IError {
 	return SQLState42846{
 		code: sqlstate_to_int('42846')
-		msg: 'cannot coerce $from to $to'
+		msg: 'cannot coerce ${from} to ${to}'
 		from: from
 		to: to
 	}
@@ -230,7 +230,7 @@ pub:
 fn sqlstate_42p01(table_name string) IError {
 	return SQLState42P01{
 		code: sqlstate_to_int('42P01')
-		msg: 'no such table: $table_name'
+		msg: 'no such table: ${table_name}'
 		table_name: table_name
 	}
 }
@@ -245,7 +245,7 @@ pub:
 fn sqlstate_42p06(schema_name string) IError {
 	return SQLState42P06{
 		code: sqlstate_to_int('42P06')
-		msg: 'duplicate schema: $schema_name'
+		msg: 'duplicate schema: ${schema_name}'
 		schema_name: schema_name
 	}
 }
@@ -260,7 +260,7 @@ pub:
 fn sqlstate_42p07(table_name string) IError {
 	return SQLState42P07{
 		code: sqlstate_to_int('42P07')
-		msg: 'duplicate table: $table_name'
+		msg: 'duplicate table: ${table_name}'
 		table_name: table_name
 	}
 }
@@ -287,7 +287,7 @@ pub:
 fn sqlstate_42p02(parameter_name string) IError {
 	return SQLState42P02{
 		code: sqlstate_to_int('42P02')
-		msg: 'parameter does not exist: $parameter_name'
+		msg: 'parameter does not exist: ${parameter_name}'
 		parameter_name: parameter_name
 	}
 }
@@ -324,7 +324,7 @@ struct SQLState0B000 {
 fn sqlstate_0b000(msg string) IError {
 	return SQLState0B000{
 		code: sqlstate_to_int('0B000')
-		msg: 'invalid transaction initiation: $msg'
+		msg: 'invalid transaction initiation: ${msg}'
 	}
 }
 
@@ -336,7 +336,7 @@ struct SQLState40001 {
 fn sqlstate_40001(message string) IError {
 	return SQLState40001{
 		code: sqlstate_to_int('40001')
-		msg: 'serialization failure: $message'
+		msg: 'serialization failure: ${message}'
 	}
 }
 

--- a/vsql/storage.v
+++ b/vsql/storage.v
@@ -51,7 +51,7 @@ fn new_storage() Storage {
 }
 
 fn (mut f Storage) open(path string) ! {
-	f.file = os.open_file(path, 'r+') or { return error('unable to open $path: $err') }
+	f.file = os.open_file(path, 'r+') or { return error('unable to open ${path}: ${err}') }
 
 	header := read_header(mut f.file)!
 
@@ -118,7 +118,7 @@ fn (mut f Storage) create_table(table_name string, columns Columns, primary_key 
 
 	table := Table{f.transaction_id, table_name, columns, primary_key, false}
 
-	obj := new_page_object('T$table_name'.bytes(), f.transaction_id, 0, table.bytes())
+	obj := new_page_object('T${table_name}'.bytes(), f.transaction_id, 0, table.bytes())
 	page_number := f.btree.add(obj)!
 	f.transaction_pages[page_number] = true
 
@@ -134,7 +134,7 @@ fn (mut f Storage) create_schema(schema_name string) ! {
 
 	schema := Schema{f.transaction_id, schema_name}
 
-	obj := new_page_object('S$schema_name'.bytes(), f.transaction_id, 0, schema.bytes())
+	obj := new_page_object('S${schema_name}'.bytes(), f.transaction_id, 0, schema.bytes())
 	page_number := f.btree.add(obj)!
 	f.transaction_pages[page_number] = true
 
@@ -148,7 +148,7 @@ fn (mut f Storage) delete_table(table_name string, tid int) ! {
 		f.isolation_end() or { panic(err) }
 	}
 
-	page_number := f.btree.expire('T$table_name'.bytes(), tid, f.transaction_id)!
+	page_number := f.btree.expire('T${table_name}'.bytes(), tid, f.transaction_id)!
 	f.transaction_pages[page_number] = true
 
 	f.tables.delete(table_name)
@@ -161,7 +161,7 @@ fn (mut f Storage) delete_schema(schema_name string, tid int) ! {
 		f.isolation_end() or { panic(err) }
 	}
 
-	page_number := f.btree.expire('S$schema_name'.bytes(), tid, f.transaction_id)!
+	page_number := f.btree.expire('S${schema_name}'.bytes(), tid, f.transaction_id)!
 	f.transaction_pages[page_number] = true
 
 	f.schemas.delete(schema_name)
@@ -211,7 +211,7 @@ fn (mut f Storage) read_rows(table_name string, prefix_table_name bool) ![]Row {
 	mut rows := []Row{}
 
 	// ';' = ':' + 1
-	for object in f.btree.new_range_iterator('R$table_name:'.bytes(), 'R$table_name;'.bytes()) {
+	for object in f.btree.new_range_iterator('R${table_name}:'.bytes(), 'R${table_name};'.bytes()) {
 		if object_is_visible(object.tid, object.xid, f.transaction_id, mut f.header.active_transaction_ids) {
 			mut prefixed_table_name := ''
 			if prefix_table_name {

--- a/vsql/table.v
+++ b/vsql/table.v
@@ -29,8 +29,8 @@ pub:
 //
 // snippet: v.Column.str
 pub fn (c Column) str() string {
-	name := if c.name.is_upper() { c.name } else { '"$c.name"' }
-	mut f := '$name $c.typ'
+	name := if c.name.is_upper() { c.name } else { '"${c.name}"' }
+	mut f := '${name} ${c.typ}'
 	if c.not_null {
 		f += ' NOT NULL'
 	}
@@ -151,11 +151,11 @@ fn new_table_from_bytes(data []u8, tid int) Table {
 //
 // snippet: v.Table.str
 pub fn (t Table) str() string {
-	mut s := 'CREATE TABLE $t.name ('
+	mut s := 'CREATE TABLE ${t.name} ('
 	mut cols := []string{}
 
 	for col in t.columns {
-		cols << '  $col'
+		cols << '  ${col}'
 	}
 
 	return s + '\n' + cols.join(',\n') + '\n);'
@@ -178,14 +178,14 @@ mut:
 }
 
 fn (o TableOperation) str() string {
-	return 'TABLE $o.table_name ($o.columns())'
+	return 'TABLE ${o.table_name} (${o.columns()})'
 }
 
 fn (o TableOperation) columns() Columns {
 	if o.prefix_table_name {
 		mut columns := []Column{}
 		for column in o.table.columns {
-			columns << Column{'${o.table_name}.$column.name', column.typ, column.not_null}
+			columns << Column{'${o.table_name}.${column.name}', column.typ, column.not_null}
 		}
 
 		return columns
@@ -201,7 +201,7 @@ fn (mut o TableOperation) execute(_ []Row) ![]Row {
 		for row in o.subplans[o.table_name].execute([]Row{})! {
 			mut data := map[string]Value{}
 			for k, v in row.data {
-				data['${o.table_name}.$k'] = v
+				data['${o.table_name}.${k}'] = v
 			}
 
 			rows << new_row(data)

--- a/vsql/time.v
+++ b/vsql/time.v
@@ -81,9 +81,9 @@ fn new_timestamp_from_string(s string) !Time {
 	mut re := regex.regex_opt(match expects_time_zone {
 		true { vsql.unquoted_timestamp_with_time_zone_string }
 		false { vsql.unquoted_timestamp_without_time_zone_string }
-	}) or { return error('cannot compile regex for timestamp: $err') }
+	}) or { return error('cannot compile regex for timestamp: ${err}') }
 	if !re.matches_string(s) {
-		return sqlstate_42601('TIMESTAMP \'$s\' is not valid')
+		return sqlstate_42601('TIMESTAMP \'${s}\' is not valid')
 	}
 
 	mut time_zone := i16(0)
@@ -98,7 +98,7 @@ fn new_timestamp_from_string(s string) !Time {
 		}
 
 		if time_zone <= -720 || time_zone >= 720 {
-			return sqlstate_42601('TIMESTAMP \'$s\' is not valid')
+			return sqlstate_42601('TIMESTAMP \'${s}\' is not valid')
 		}
 
 		// If we don't trim off the time zone, V will try and interpret it but
@@ -116,7 +116,7 @@ fn new_timestamp_from_string(s string) !Time {
 	}
 
 	return Time{typ, time_zone, time.parse_iso8601(to_parse) or {
-		return sqlstate_42601('TIMESTAMP \'$s\' is not valid')
+		return sqlstate_42601('TIMESTAMP \'${s}\' is not valid')
 	}}
 }
 
@@ -127,8 +127,8 @@ fn new_time_from_string(s string) !Time {
 	// part. We use 1970-01-01 because internally we still need to rely on the
 	// unix timestamp in V's Time object. This data part will be ignored in
 	// actual calculations.
-	mut t := new_timestamp_from_string('1970-01-01 $s') or {
-		return sqlstate_42601('TIME \'$s\' is not valid')
+	mut t := new_timestamp_from_string('1970-01-01 ${s}') or {
+		return sqlstate_42601('TIME \'${s}\' is not valid')
 	}
 
 	if t.typ.typ == .is_timestamp_with_time_zone {
@@ -145,8 +145,8 @@ fn new_time_from_string(s string) !Time {
 fn new_date_from_string(s string) !Time {
 	// The easiest way to parse it is as a normal timestamp with a dummy time
 	// part.
-	mut t := new_timestamp_from_string('$s 00:00:00') or {
-		return sqlstate_42601('DATE \'$s\' is not valid')
+	mut t := new_timestamp_from_string('${s} 00:00:00') or {
+		return sqlstate_42601('DATE \'${s}\' is not valid')
 	}
 
 	t.typ.typ = .is_date
@@ -369,9 +369,9 @@ fn (t Time) str_time_zone(allow_time_zone bool, sql_formatting bool) string {
 	minutes := time_zone % 60
 
 	if hours < 10 {
-		s += '0$hours'
+		s += '0${hours}'
 	} else {
-		s += '$hours'
+		s += '${hours}'
 	}
 
 	if sql_formatting {
@@ -379,9 +379,9 @@ fn (t Time) str_time_zone(allow_time_zone bool, sql_formatting bool) string {
 	}
 
 	if minutes < 10 {
-		s += '0$minutes'
+		s += '0${minutes}'
 	} else {
-		s += '$minutes'
+		s += '${minutes}'
 	}
 
 	return s

--- a/vsql/type.v
+++ b/vsql/type.v
@@ -124,7 +124,7 @@ fn (t Type) str() string {
 		}
 		.is_character {
 			if t.size > 0 {
-				'CHARACTER($t.size)'
+				'CHARACTER(${t.size})'
 			} else {
 				'CHARACTER'
 			}
@@ -145,7 +145,7 @@ fn (t Type) str() string {
 			// TODO(elliotchance): Is this a bug to allow no size for CHARACTER
 			//  VARYING? Need to check standard.
 			if t.size > 0 {
-				'CHARACTER VARYING($t.size)'
+				'CHARACTER VARYING(${t.size})'
 			} else {
 				'CHARACTER VARYING'
 			}
@@ -154,16 +154,16 @@ fn (t Type) str() string {
 			'DATE'
 		}
 		.is_time_without_time_zone {
-			'TIME($t.size) WITHOUT TIME ZONE'
+			'TIME(${t.size}) WITHOUT TIME ZONE'
 		}
 		.is_time_with_time_zone {
-			'TIME($t.size) WITH TIME ZONE'
+			'TIME(${t.size}) WITH TIME ZONE'
 		}
 		.is_timestamp_without_time_zone {
-			'TIMESTAMP($t.size) WITHOUT TIME ZONE'
+			'TIMESTAMP(${t.size}) WITHOUT TIME ZONE'
 		}
 		.is_timestamp_with_time_zone {
-			'TIMESTAMP($t.size) WITH TIME ZONE'
+			'TIMESTAMP(${t.size}) WITH TIME ZONE'
 		}
 	}
 
@@ -251,13 +251,13 @@ fn type_from_number(number u8, size int) Type {
 		3 { 'INTEGER' }
 		4 { 'REAL' }
 		5 { 'SMALLINT' }
-		6 { 'CHARACTER VARYING($size)' }
+		6 { 'CHARACTER VARYING(${size})' }
 		7 { 'CHARACTER' }
 		8 { 'DATE' }
-		9 { 'TIME($size) WITH TIME ZONE' }
-		10 { 'TIME($size) WITHOUT TIME ZONE' }
-		11 { 'TIMESTAMP($size) WITH TIME ZONE' }
-		12 { 'TIMESTAMP($size) WITHOUT TIME ZONE' }
+		9 { 'TIME(${size}) WITH TIME ZONE' }
+		10 { 'TIME(${size}) WITHOUT TIME ZONE' }
+		11 { 'TIMESTAMP(${size}) WITH TIME ZONE' }
+		12 { 'TIMESTAMP(${size}) WITHOUT TIME ZONE' }
 		else { panic(number) }
 	}, 0)
 }

--- a/vsql/update.v
+++ b/vsql/update.v
@@ -44,7 +44,7 @@ fn execute_update(mut c Connection, stmt UpdateStmt, params map[string]Value, el
 			return sqlstate_3f000(parts[0]) // scheme does not exist
 		}
 	} else {
-		table_name = 'PUBLIC.$table_name'
+		table_name = 'PUBLIC.${table_name}'
 	}
 
 	table := c.storage.tables[table_name]
@@ -66,7 +66,7 @@ fn execute_update(mut c Connection, stmt UpdateStmt, params map[string]Value, el
 			raw_value := eval_as_nullable_value(c, table_column.typ.typ, row, v, params)!
 
 			if table_column.not_null && raw_value.is_null {
-				return sqlstate_23502('column $column_name')
+				return sqlstate_23502('column ${column_name}')
 			}
 
 			// Unlike most comparisons we have to treat NULL like a known value
@@ -79,7 +79,7 @@ fn execute_update(mut c Connection, stmt UpdateStmt, params map[string]Value, el
 			cmp, is_null := row.data[column_name].cmp(raw_value)!
 			if is_null || cmp != 0 {
 				did_modify = true
-				row2.data[column_name] = cast(c, 'for column $column_name', raw_value,
+				row2.data[column_name] = cast(c, 'for column ${column_name}', raw_value,
 					table_column.typ)!
 			}
 		}
@@ -104,13 +104,13 @@ fn execute_update(mut c Connection, stmt UpdateStmt, params map[string]Value, el
 			table_column := table.column(column_name)!
 			raw_value := eval_as_nullable_value(c, table_column.typ.typ, empty_row, v,
 				params)!
-			value := cast(c, 'for column $column_name', raw_value, table_column.typ)!
+			value := cast(c, 'for column ${column_name}', raw_value, table_column.typ)!
 
 			if table_column.not_null && value.is_null {
-				return sqlstate_23502('column $column_name')
+				return sqlstate_23502('column ${column_name}')
 			}
 		}
 	}
 
-	return new_result_msg('UPDATE $modify_count', elapsed_parse, t.elapsed())
+	return new_result_msg('UPDATE ${modify_count}', elapsed_parse, t.elapsed())
 }

--- a/vsql/value.v
+++ b/vsql/value.v
@@ -301,10 +301,10 @@ pub fn (v Value) cmp(v2 Value) !(int, bool) {
 		return cmp_value(v.string_value, v2.string_value)
 	}
 
-	return error('cannot compare $v.typ and $v2.typ')
+	return error('cannot compare ${v.typ} and ${v2.typ}')
 }
 
-fn cmp_value<A, B>(lhs A, rhs B) (int, bool) {
+fn cmp_value[A, B](lhs A, rhs B) (int, bool) {
 	if lhs < rhs {
 		return -1, false
 	}

--- a/vsql/values.v
+++ b/vsql/values.v
@@ -34,7 +34,7 @@ fn (o &ValuesOperation) str() string {
 		rows << row.pstr(o.params)
 	}
 
-	return 'VALUES ($o.columns()) = ${rows.join(', ')}'
+	return 'VALUES (${o.columns()}) = ${rows.join(', ')}'
 }
 
 fn (o &ValuesOperation) columns() Columns {
@@ -58,7 +58,7 @@ fn (o &ValuesOperation) columns() Columns {
 	for i in 1 .. o.rows[0].exprs.len + 1 {
 		typ := eval_as_type(o.conn, Row{}, o.rows[0].exprs[i - 1], o.params) or { panic(err) }
 		columns << Column{
-			name: new_identifier('COL$i').name
+			name: new_identifier('COL${i}').name
 			typ: typ
 		}
 	}
@@ -89,7 +89,7 @@ fn (o &ValuesOperation) execute(_ []Row) ![]Row {
 			mut data := map[string]Value{}
 			for i in 1 .. row.data.len + 1 {
 				name := columns[i - 1].name
-				data[name] = row.data['COL$i']
+				data[name] = row.data['COL${i}']
 			}
 
 			row = Row{

--- a/vsql/virtual_table.v
+++ b/vsql/virtual_table.v
@@ -52,14 +52,14 @@ struct VirtualTableOperation {
 }
 
 fn (o VirtualTableOperation) str() string {
-	return 'VIRTUAL TABLE $o.table_name ($o.columns())'
+	return 'VIRTUAL TABLE ${o.table_name} (${o.columns()})'
 }
 
 fn (o VirtualTableOperation) columns() Columns {
 	mut columns := []Column{}
 
 	for column in o.table.create_table_stmt.columns() {
-		columns << Column{'${o.table.create_table_stmt.table_name}.$column.name', column.typ, column.not_null}
+		columns << Column{'${o.table.create_table_stmt.table_name}.${column.name}', column.typ, column.not_null}
 	}
 
 	return columns
@@ -79,7 +79,7 @@ fn (o VirtualTableOperation) execute(_ []Row) ![]Row {
 		mut data := map[string]Value{}
 
 		for k, v in row.data {
-			data['${table_name}.$k'] = v
+			data['${table_name}.${k}'] = v
 		}
 
 		new_rows << new_row(data)

--- a/vsql/walk.v
+++ b/vsql/walk.v
@@ -101,7 +101,7 @@ fn new_primary_key_operation(table Table, lower Expr, upper Expr, params map[str
 }
 
 fn (o &PrimaryKeyOperation) str() string {
-	return 'PRIMARY KEY $o.table.name ($o.columns()) BETWEEN ${o.lower.pstr(o.params)} AND ${o.upper.pstr(o.params)}'
+	return 'PRIMARY KEY ${o.table.name} (${o.columns()}) BETWEEN ${o.lower.pstr(o.params)} AND ${o.upper.pstr(o.params)}'
 }
 
 fn (o &PrimaryKeyOperation) columns() Columns {
@@ -109,7 +109,7 @@ fn (o &PrimaryKeyOperation) columns() Columns {
 		mut columns := []Column{}
 
 		for column in o.table.columns {
-			columns << Column{'${o.table.name}.$column.name', column.typ, column.not_null}
+			columns << Column{'${o.table.name}.${column.name}', column.typ, column.not_null}
 		}
 
 		return columns


### PR DESCRIPTION
This is a followup to https://github.com/elliotchance/vsql/pull/136 , and just fixes a single notice, produced by v for just doing `import elliotchance.vsql.vsql` in a .v file.

I am not sure, if that is the proper way to fix it though, may be another implementation of the Pager interface may be more suitable as a default?

p.s. the only difference with #136 is in the last commit, concerning https://github.com/elliotchance/vsql/pull/137/files#diff-edbec55c81fee9e177dc60d8199287f8426ea3a584cfbee123d73077b832df39R28 .