### PR TITLE
make: fix too lax loops in `make cli-test` and `make examples`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ sql-test:
 
 cli-test: bin/vsql
 	for f in `ls cmd/tests/*.sh`; do \
-		VSQL=bin/vsql ./$$f ; \
+		echo $$f; VSQL=bin/vsql ./$$f || exit 1; \
 	done
 
 cmd/tests/%: bin/vsql
@@ -73,7 +73,7 @@ cmd/tests/%: bin/vsql
 
 examples:
 	for f in `ls examples/*.v`; do \
-		v run $$f ; \
+		echo $$f; v run $$f || exit 1; \
 	done
 
 examples/%:

--- a/cmd/tests/missing-command.sh
+++ b/cmd/tests/missing-command.sh
@@ -2,4 +2,6 @@
 
 set -e
 
-$VSQL && exit 0
+$VSQL || exit 0
+
+exit 1

--- a/cmd/tests/unknown-command.sh
+++ b/cmd/tests/unknown-command.sh
@@ -2,4 +2,6 @@
 
 set -e
 
-$VSQL no-such-command && exit 0
+$VSQL no-such-command || exit 0
+
+exit 1

--- a/vsql/sql_test.v
+++ b/vsql/sql_test.v
@@ -173,7 +173,7 @@ fn run_single_test(test SQLTest, query_cache &QueryCache, verbose bool, filter_l
 				connections[connection_name] = conn
 			}
 
-			db = connections[connection_name] or { continue }
+			db = connections[connection_name] or { panic('unknown connection: ${connection_name}') }
 			current_connection_name = connection_name
 			continue
 		}

--- a/vsql/sql_test.v
+++ b/vsql/sql_test.v
@@ -173,7 +173,7 @@ fn run_single_test(test SQLTest, query_cache &QueryCache, verbose bool, filter_l
 				connections[connection_name] = conn
 			}
 
-			db = connections[connection_name]
+			db = connections[connection_name] or { continue }
 			current_connection_name = connection_name
 			continue
 		}


### PR DESCRIPTION
This PR lets those make targets fail, if any of the steps in their loops fail .