### PR TITLE
Adding warnings

### DIFF
--- a/cmd/vsql/cli.v
+++ b/cmd/vsql/cli.v
@@ -18,6 +18,7 @@ fn register_cli_command(mut cmd cli.Command) {
 
 fn cli_command(cmd cli.Command) ! {
 	print_version()
+	println('')
 
 	mut db := vsql.open(cmd.args[0])!
 
@@ -41,9 +42,14 @@ fn cli_command(cmd cli.Command) ! {
 
 		if query != '' {
 			start := time.ticks()
+			db.clear_warnings()
 			result := db.query(query) or {
-				print_error(err)
+				print_error('Error', err)
 				continue
+			}
+
+			for warning in db.warnings {
+				print_error('Warning', warning)
 			}
 
 			mut total_rows := 0
@@ -71,10 +77,10 @@ fn cli_command(cmd cli.Command) ! {
 	}
 }
 
-fn print_error(err IError) {
+fn print_error(prefix string, err IError) {
 	if err.code() > 0 {
 		sqlstate := vsql.sqlstate_from_int(err.code())
-		println('${sqlstate}: ${err.msg()}\n')
+		println('${prefix} ${sqlstate}: ${err.msg()}\n')
 	} else {
 		println('ERROR: ${err}\n')
 	}

--- a/docs/v-client-library-docs.rst
+++ b/docs/v-client-library-docs.rst
@@ -414,6 +414,14 @@ struct Connection
    	// in UTC with a separate offset for the current local timezone (in positive
    	// or negative minutes).
    	now fn () (time.Time, i16)
+   	// warnings are SQLSTATE errors that do not stop the execution. For example,
+   	// if a value must be truncated during a runtime CAST.
+   	//
+   	// Warnings are not ever reset, although only 100 of the most recent warnings
+   	// are retained. This is to be able to collect all warnings during some
+   	// arbitrary process defined by the application. Instead, you should call
+   	// clear_warnings() before starting a block of work.
+   	warnings []IError
    }
 
 

--- a/tests/character-varying.sql
+++ b/tests/character-varying.sql
@@ -10,7 +10,8 @@ INSERT INTO foo (x) VALUES ('hello');
 SELECT CAST(x AS VARCHAR(4)) FROM foo;
 -- msg: CREATE TABLE 1
 -- msg: INSERT 1
--- error 22001: string data right truncation for CHARACTER VARYING(4)
+-- warning 22001: string data right truncation for CHARACTER VARYING(4)
+-- COL1: hell
 
 CREATE TABLE foo (x CHARACTER VARYING(8));
 INSERT INTO foo (x) VALUES ('hello');

--- a/tests/character.sql
+++ b/tests/character.sql
@@ -17,7 +17,8 @@ INSERT INTO foo (x) VALUES ('hello');
 SELECT CAST(x AS VARCHAR(4)) FROM foo;
 -- msg: CREATE TABLE 1
 -- msg: INSERT 1
--- error 22001: string data right truncation for CHARACTER VARYING(4)
+-- warning 22001: string data right truncation for CHARACTER VARYING(4)
+-- COL1: hell
 
 CREATE TABLE foo (x CHARACTER(8));
 INSERT INTO foo (x) VALUES ('hello');

--- a/tests/insert.sql
+++ b/tests/insert.sql
@@ -112,5 +112,7 @@ INSERT INTO t1 (f1) VALUES ('too long');
 SELECT * FROM t1;
 -- msg: CREATE TABLE 1
 -- msg: INSERT 1
--- error 22001: string data right truncation for CHARACTER VARYING(4)
+-- warning 22001: string data right truncation for CHARACTER VARYING(4)
+-- msg: INSERT 1
 -- F1: abc
+-- F1: too

--- a/tests/update.sql
+++ b/tests/update.sql
@@ -103,5 +103,6 @@ UPDATE foo SET baz = 'too long';
 SELECT * FROM foo;
 -- msg: CREATE TABLE 1
 -- msg: INSERT 1
--- error 22001: string data right truncation for CHARACTER VARYING(4)
--- BAZ: abc
+-- warning 22001: string data right truncation for CHARACTER VARYING(4)
+-- msg: UPDATE 1
+-- BAZ: too

--- a/vsql/cast.v
+++ b/vsql/cast.v
@@ -231,33 +231,41 @@ fn cast_double_precision_to_real(conn &Connection, v Value, to Type) !Value {
 	return new_real_value(f32(v.f64_value()))
 }
 
-fn cast_varchar_to_varchar(conn &Connection, v Value, to Type) !Value {
+fn cast_varchar_to_varchar(mut conn Connection, v Value, to Type) !Value {
 	if to.size > 0 && v.string_value().len > to.size {
-		return sqlstate_22001(to)
+		conn.add_warning(sqlstate_22001(to))
+
+		return new_varchar_value(v.string_value()[..to.size], to.size)
 	}
 
 	return new_varchar_value(v.string_value(), to.size)
 }
 
-fn cast_varchar_to_character(conn &Connection, v Value, to Type) !Value {
+fn cast_varchar_to_character(mut conn Connection, v Value, to Type) !Value {
 	if to.size > 0 && v.string_value().len > to.size {
-		return sqlstate_22001(to)
+		conn.add_warning(sqlstate_22001(to))
+
+		return new_varchar_value(v.string_value()[..to.size], to.size)
 	}
 
 	return new_character_value(v.string_value(), to.size)
 }
 
-fn cast_character_to_varchar(conn &Connection, v Value, to Type) !Value {
+fn cast_character_to_varchar(mut conn Connection, v Value, to Type) !Value {
 	if to.size > 0 && v.string_value().len > to.size {
-		return sqlstate_22001(to)
+		conn.add_warning(sqlstate_22001(to))
+
+		return new_varchar_value(v.string_value()[..to.size], to.size)
 	}
 
 	return new_varchar_value(v.string_value(), to.size)
 }
 
-fn cast_character_to_character(conn &Connection, v Value, to Type) !Value {
+fn cast_character_to_character(mut conn Connection, v Value, to Type) !Value {
 	if to.size > 0 && v.string_value().len > to.size {
-		return sqlstate_22001(to)
+		conn.add_warning(sqlstate_22001(to))
+
+		return new_varchar_value(v.string_value()[..to.size], to.size)
 	}
 
 	return new_character_value(v.string_value(), to.size)

--- a/vsql/sql_test.v
+++ b/vsql/sql_test.v
@@ -194,6 +194,7 @@ fn run_single_test(test SQLTest, query_cache &QueryCache, verbose bool, filter_l
 			actual += 'error ${sqlstate_from_int(err.code())}: ${err.msg()}\n'
 			continue
 		}
+		db.clear_warnings()
 		result := prepared.query(test.params) or {
 			if current_connection_name == '' {
 				actual += 'error ${sqlstate_from_int(err.code())}: ${err.msg()}\n'
@@ -202,6 +203,10 @@ fn run_single_test(test SQLTest, query_cache &QueryCache, verbose bool, filter_l
 			}
 
 			continue
+		}
+
+		for err in db.warnings {
+			actual += 'warning ${sqlstate_from_int(err.code())}: ${err.msg()}\n'
 		}
 
 		for row in result {


### PR DESCRIPTION
Warnings are SQLSTATE errors that do not stop the execution. For example,  if a value must be truncated during a runtime CAST.

Warnings are not ever reset, although only 100 of the most recent warnings are retained. This is to be able to collect all warnings during some arbitrary process defined by the application. Instead, you should call clear_warnings() before starting a block of work.