### PR TITLE
sequences: Fix transaction isolation

### DIFF
--- a/docs/alter-sequence.rst
+++ b/docs/alter-sequence.rst
@@ -44,16 +44,6 @@ Examples
    -- msg: ALTER SEQUENCE 1
    -- COL1: 1 COL2: 2
 
-Caveats
--------
-
-The properties of a sequence (such as the ``INCREMENT BY``, etc) are held in the
-same record as the next value. Since the next value of a sequence needs to be
-atomic (and separate from the transaction isolation) a ``ROLLBACK`` on a
-transaction that contains an ``ALTER SEQUENCE`` will not undo any changes.
-
-This was noted in :doc:`file-format` under *Notes for Future Improvements*.
-
 See Also
 --------
 

--- a/docs/file-format.rst
+++ b/docs/file-format.rst
@@ -124,6 +124,9 @@ the first byte of the *Key*:
   * - ``F``
     - `Fragment Object`_
 
+  * - ``Q``
+    - `Sequence Object`_
+
   * - ``R``
     - `Row Object`_
 
@@ -132,6 +135,9 @@ the first byte of the *Key*:
 
   * - ``T``
     - `Table Object`_
+
+  * - ``V``
+    - `Sequence Value Object`_
 
 Every object contains 15 bytes of metadata:
 
@@ -210,10 +216,15 @@ code for ``Schema.bytes()`` and ``new_schema_from_bytes()`` respectively.
 Sequence Object
 ---------------
 
-A Sequence Object (has the ``Q`` prefix) contains the definition and next value
-for a sequence. Since a sequence's next value needs to be atomic, this creates
-some special rules that only apply to updating or incrementing a sequence. See
-*Notes for Future Improvements* below or *Caveats* in :doc:`alter-sequence`.
+A Sequence Object (has the ``Q`` prefix) contains the definition for a sequence
+(not including the next value, see `Sequence Value Object`_).
+
+Sequence Value Object
+---------------------
+
+A Sequence Value Object (has the ``V`` prefix) contains the next value for a
+sequence. Since a sequence's next value needs to be atomic, even outside of
+transaction isolation, changing the value will be always persistent.
 
 Table Object
 ------------

--- a/vsql/header.v
+++ b/vsql/header.v
@@ -7,7 +7,7 @@ import os
 // This is a rudimentary way to ensure that small changes to storage.v are
 // compatible as things change so rapidly. Sorry if you had a database in a
 // previous version, you'll need to recreate it.
-const current_version = i8(11)
+const current_version = i8(12)
 
 // The Header contains important metadata about the database and always occupies
 // the first page of the database.

--- a/vsql/order.v
+++ b/vsql/order.v
@@ -40,7 +40,7 @@ fn (mut o OrderOperation) execute(rows []Row) ![]Row {
 	// This sorting implementation uses a linked list which is very simple but
 	// very expensive at O(n^2).
 
-	mut head := &RowLink(0)
+	mut head := &RowLink(unsafe { nil })
 	for row in rows {
 		// First item is assigned to head.
 		if unsafe { head == 0 } {

--- a/vsql/sequence.v
+++ b/vsql/sequence.v
@@ -88,11 +88,10 @@ fn (s Sequence) next() !Sequence {
 	return Sequence{s.tid, s.name, next_value, s.increment_by, s.cycle, s.has_min_value, s.min_value, s.has_max_value, s.max_value}
 }
 
-fn (s Sequence) bytes() []u8 {
+fn (s Sequence) definition_bytes() []u8 {
 	mut b := new_empty_bytes()
 
 	b.write_string1(s.name.storage_id())
-	b.write_i64(s.current_value)
 	b.write_i64(s.increment_by)
 	b.write_bool(s.cycle)
 	b.write_optional_i64(s.has_min_value, s.min_value)
@@ -101,15 +100,24 @@ fn (s Sequence) bytes() []u8 {
 	return b.bytes()
 }
 
-fn new_sequence_from_bytes(data []u8, tid int) Sequence {
-	mut b := new_bytes(data)
+fn (s Sequence) value_bytes() []u8 {
+	mut b := new_empty_bytes()
 
-	sequence_name := b.read_identifier()
-	current_value := b.read_i64()
-	increment_by := b.read_i64()
-	cycle := b.read_bool()
-	has_min_value, min_value := b.read_optional_i64()
-	has_max_value, max_value := b.read_optional_i64()
+	b.write_i64(s.current_value)
+
+	return b.bytes()
+}
+
+fn new_sequence_from_bytes(definition_data []u8, value_data []u8, tid int) Sequence {
+	mut b1 := new_bytes(definition_data)
+	sequence_name := b1.read_identifier()
+	increment_by := b1.read_i64()
+	cycle := b1.read_bool()
+	has_min_value, min_value := b1.read_optional_i64()
+	has_max_value, max_value := b1.read_optional_i64()
+
+	mut b2 := new_bytes(value_data)
+	current_value := b2.read_i64()
 
 	return Sequence{tid, sequence_name, current_value, increment_by, cycle, has_min_value, min_value, has_max_value, max_value}
 }


### PR DESCRIPTION
Previously the sequence definition and the value were stored in the same record. However, the value needs to be persistent outside of any transaction isolation. To work around this, the definition could not be rolled back with the transaction to prevent the value from also being rolled back.

This separates the next value so we no longer have this caveat, but it requires a bump in the DB comparability version.