### PR TITLE
ci: fix warnings and notices when compiling with latest V 0.4.0 320057d

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,6 @@ jobs:
       - name: Verify fmt
         run: make fmt-verify
 
-      - name: Verify docs
-        run: |
-          pip install sphinx sphinx_rtd_theme
-          cd docs && python3 -m pip install -r requirements.txt && cd -
-          make clean-docs docs
-          git diff --exit-code
-
       - name: Run SQL and B-tree tests
         run: make test
 
@@ -46,6 +39,13 @@ jobs:
 
       - name: Run CLI tests
         run: make cli-test
+
+      - name: Verify docs
+        run: |
+          pip install sphinx sphinx_rtd_theme
+          cd docs && python3 -m pip install -r requirements.txt && cd -
+          make clean-docs docs
+          git diff --exit-code
 
   macos-binary:
     name: Build for macOS

--- a/docs/v-client-library-docs.rst
+++ b/docs/v-client-library-docs.rst
@@ -23,67 +23,6 @@ fn catalog_name_from_path
 
 
 
-fn new_varchar_value
---------------------
-
-
-.. code-block:: v
-
-   pub fn new_varchar_value(x string) Value
-
-
-new_varchar_value creates a ``CHARACTER VARYING`` value.  
-
-fn open
--------
-
-
-.. code-block:: v
-
-   pub fn open(path string) !&Connection
-
-
-open is the convenience function for open_database() with default options.  
-
-fn open_database
-----------------
-
-
-.. code-block:: v
-
-   pub fn open_database(path string, options ConnectionOptions) !&Connection
-
-
-open_database will open an existing database file or create a new file if the
-path does not exist.  
-
-If the file does exist, open_database will assume that the file is a valid database file (not corrupt). Otherwise unexpected behavior or even a crash
-may occur.  
-
-The special file name ":memory:" can be used to create an entirely in-memory database. This will be faster but all data will be lost when the connection
-is closed.  
-
-open_database can be used concurrently for reading and writing to the same file and provides the following default protections:
-
-- Fine: Multiple processes open_database() the same file.
-
-- Fine: Multiple goroutines sharing an open_database() on the same file.
-
-- Bad: Multiple goroutines open_database() the same file.
-
-See ConnectionOptions and default_connection_options().  
-
-fn pluralize
-------------
-
-
-.. code-block:: v
-
-   pub fn pluralize(n int, word string) string
-
-
-TODO(elliotchance): Make private when CLI is moved into vsql package.  
-
 fn default_connection_options
 -----------------------------
 
@@ -116,41 +55,6 @@ fn new_bigint_value
 
 
 new_bigint_value creates a ``BIGINT`` value.  
-
-fn sqlstate_from_int
---------------------
-
-
-.. code-block:: v
-
-   pub fn sqlstate_from_int(code int) string
-
-
-sqlstate_from_int performs the inverse operation of sqlstate_to_int.  
-
-fn sqlstate_to_int
-------------------
-
-
-.. code-block:: v
-
-   pub fn sqlstate_to_int(code string) int
-
-
-sqlstate_to_int converts the 5 character SQLSTATE code (such as "42P01") into an integer representation. The returned value can be converted back to its
-respective string by using sqlstate_from_int().  
-
-If code is invalid the result will be unexpected.  
-
-fn start_timer
---------------
-
-
-.. code-block:: v
-
-   pub fn start_timer() Timer
-
-
 
 fn new_boolean_value
 --------------------
@@ -308,7 +212,103 @@ fn new_unknown_value
 new_unknown_value returns an ``UNKNOWN`` value. This is the ``NULL``
 representation of ``BOOLEAN``.  
 
-type Server
+fn new_varchar_value
+--------------------
+
+
+.. code-block:: v
+
+   pub fn new_varchar_value(x string) Value
+
+
+new_varchar_value creates a ``CHARACTER VARYING`` value.  
+
+fn open
+-------
+
+
+.. code-block:: v
+
+   pub fn open(path string) !&Connection
+
+
+open is the convenience function for open_database() with default options.  
+
+fn open_database
+----------------
+
+
+.. code-block:: v
+
+   pub fn open_database(path string, options ConnectionOptions) !&Connection
+
+
+open_database will open an existing database file or create a new file if the
+path does not exist.  
+
+If the file does exist, open_database will assume that the file is a valid database file (not corrupt). Otherwise unexpected behavior or even a crash
+may occur.  
+
+The special file name ":memory:" can be used to create an entirely in-memory database. This will be faster but all data will be lost when the connection
+is closed.  
+
+open_database can be used concurrently for reading and writing to the same file and provides the following default protections:
+
+- Fine: Multiple processes open_database() the same file.
+
+- Fine: Multiple goroutines sharing an open_database() on the same file.
+
+- Bad: Multiple goroutines open_database() the same file.
+
+See ConnectionOptions and default_connection_options().  
+
+fn pluralize
+------------
+
+
+.. code-block:: v
+
+   pub fn pluralize(n int, word string) string
+
+
+TODO(elliotchance): Make private when CLI is moved into vsql package.  
+
+fn sqlstate_from_int
+--------------------
+
+
+.. code-block:: v
+
+   pub fn sqlstate_from_int(code int) string
+
+
+sqlstate_from_int performs the inverse operation of sqlstate_to_int.  
+
+fn sqlstate_to_int
+------------------
+
+
+.. code-block:: v
+
+   pub fn sqlstate_to_int(code string) int
+
+
+sqlstate_to_int converts the 5 character SQLSTATE code (such as "42P01") into an integer representation. The returned value can be converted back to its
+respective string by using sqlstate_from_int().  
+
+If code is invalid the result will be unexpected.  
+
+fn start_timer
+--------------
+
+
+.. code-block:: v
+
+   pub fn start_timer() Timer
+
+
+
+type Column
 -----------
 
 
@@ -320,7 +320,7 @@ type Row
 
 
 
-type Column
+type Server
 -----------
 
 
@@ -342,19 +342,19 @@ enum Boolean
 
 Possible values for a BOOLEAN.  
 
-struct VirtualTable
--------------------
+struct Benchmark
+----------------
 
 
 .. code-block:: v
 
-   pub struct VirtualTable {
-   	create_table_sql  string
-   	create_table_stmt CreateTableStmt
-   	data              VirtualTableProviderFn
-   mut:
-   	is_done bool
-   	rows    []Row
+   pub struct Benchmark {
+   pub mut:
+   	conn         &Connection
+   	account_rows int
+   	teller_rows  int
+   	branch_rows  int
+   	run_for      time.Duration
    }
 
 
@@ -413,7 +413,7 @@ struct Connection
    	// now allows you to override the wall clock that is used. The Time must be
    	// in UTC with a separate offset for the current local timezone (in positive
    	// or negative minutes).
-   	now fn () (time.Time, i16)
+   	now fn () (time.Time, i16) = unsafe { nil }
    	// warnings are SQLSTATE errors that do not stop the execution. For example,
    	// if a value must be truncated during a runtime CAST.
    	//
@@ -752,19 +752,19 @@ struct Value
 
 A single value. It contains it's type information in ``typ``.  
 
-struct Benchmark
-----------------
+struct VirtualTable
+-------------------
 
 
 .. code-block:: v
 
-   pub struct Benchmark {
-   pub mut:
-   	conn         &Connection
-   	account_rows int
-   	teller_rows  int
-   	branch_rows  int
-   	run_for      time.Duration
+   pub struct VirtualTable {
+   	create_table_sql  string
+   	create_table_stmt CreateTableStmt
+   	data              VirtualTableProviderFn = unsafe { nil }
+   mut:
+   	is_done bool
+   	rows    []Row
    }
 
 

--- a/scripts/generate-v-client-library-docs.vsh
+++ b/scripts/generate-v-client-library-docs.vsh
@@ -29,7 +29,8 @@ fn main() {
 	println('-'.repeat(module_title.len))
 	print('\n')
 
-	dcs_contents := d.contents.arr()
+	mut dcs_contents := d.contents.arr()
+	dcs_contents.sort_by_name()
 
 	for node in dcs_contents {
 		section_title := if node.kind == .const_group {

--- a/scripts/generate-v-client-library-docs.vsh
+++ b/scripts/generate-v-client-library-docs.vsh
@@ -30,7 +30,7 @@ fn main() {
 	print('\n')
 
 	mut dcs_contents := d.contents.arr()
-	dcs_contents.sort_by_name()
+	dcs_contents.sort_by_kind()
 
 	for node in dcs_contents {
 		section_title := if node.kind == .const_group {

--- a/vsql/btree_test.v
+++ b/vsql/btree_test.v
@@ -18,10 +18,10 @@ fn test_btree_test() ! {
 	blob_sizes := [
 		// 48 means all objects will fit in pages (and several per page) and
 		// never have to use blob storage.
-		48
+		48,
 		// 148 is larger than half a page so we always end up with one object
 		// per page, but no need to use blob storage, yet.
-		148
+		148,
 		// 348 is larger than a page so all items must go into blob storage.
 		348,
 	]

--- a/vsql/connection.v
+++ b/vsql/connection.v
@@ -51,7 +51,7 @@ pub mut:
 	// now allows you to override the wall clock that is used. The Time must be
 	// in UTC with a separate offset for the current local timezone (in positive
 	// or negative minutes).
-	now fn () (time.Time, i16)
+	now fn () (time.Time, i16) = unsafe { nil }
 	// warnings are SQLSTATE errors that do not stop the execution. For example,
 	// if a value must be truncated during a runtime CAST.
 	//

--- a/vsql/eval.v
+++ b/vsql/eval.v
@@ -293,7 +293,7 @@ fn time_value(conn &Connection, prec int, include_offset bool) string {
 	mut s := now.strftime('%H:%M:%S')
 
 	if prec > 0 {
-		microseconds := left_pad(now.microsecond.str(), '0', 6)
+		microseconds := left_pad((now.nanosecond / 1000).str(), '0', 6)
 		s += '.' + microseconds.substr(0, prec)
 	}
 

--- a/vsql/funcs.v
+++ b/vsql/funcs.v
@@ -6,7 +6,7 @@ struct Func {
 	name        string
 	arg_types   []Type
 	is_agg      bool
-	func        fn ([]Value) !Value
+	func        fn ([]Value) !Value = unsafe { nil }
 	return_type Type
 }
 

--- a/vsql/time.v
+++ b/vsql/time.v
@@ -154,7 +154,7 @@ fn new_time_from_components(typ Type, year int, month int, day int, hour int, mi
 		hour: hour
 		minute: minute
 		second: second
-		microsecond: microsecond
+		nanosecond: microsecond * 1000
 	})}
 }
 
@@ -237,7 +237,7 @@ fn (t Time) i64() i64 {
 // See i64() for details.
 fn (t Time) time_i64() i64 {
 	return t.t.hour * vsql.hour_period + t.t.minute * vsql.minute_period +
-		t.t.second * vsql.second_period + t.t.microsecond
+		t.t.second * vsql.second_period + t.t.nanosecond / 1000
 }
 
 // See i64() for details.
@@ -312,7 +312,7 @@ fn (t Time) str_fractional_seconds(prec int) string {
 	}
 
 	// Round down first, if needed.
-	mut s := t.t.microsecond.str()
+	mut s := (t.t.nanosecond / 1000).str()
 	if prec < s.len {
 		s = s[..prec]
 	}

--- a/vsql/virtual_table.v
+++ b/vsql/virtual_table.v
@@ -6,7 +6,7 @@ type VirtualTableProviderFn = fn (mut t VirtualTable) !
 pub struct VirtualTable {
 	create_table_sql  string
 	create_table_stmt CreateTableStmt
-	data              VirtualTableProviderFn
+	data              VirtualTableProviderFn = unsafe { nil }
 mut:
 	is_done bool
 	rows    []Row


### PR DESCRIPTION
After the deprecation of the .microsecond field of time.Time, and the addition of a notice about uninitialised fn callback fields, vsql can not be compiled cleanly with just `make bin/vsql` .

This PR fixes it.