### PR TITLE
ci: Run tests against any version of V

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -324,3 +324,18 @@ Running the specific test again can be done with:
 .. code-block:: sh
 
    TEST=subquery:32 make sql-test
+
+Using Different V Versions
+--------------------------
+
+Sometimes there are V language changes which might break tests, or otherwise
+cause issues on newer versions. Fortunatly there is a `oldv` tool which can be
+used to compile older version of `v` for testing. You can run tests simply by
+supplying a different version of V:
+
+.. code-block:: sh
+
+   OLDV=0.3.5 make sql-test
+
+You can use any commit or tag for ``OLDV``. All tags can be
+`found here <https://github.com/vlang/v/tags>`_.

--- a/docs/v-client-library-docs.rst
+++ b/docs/v-client-library-docs.rst
@@ -335,8 +335,8 @@ enum Boolean
    pub enum Boolean {
    	// These must not be negative values because they are encoded as u8 on disk.
    	is_unknown = 0 // same as NULL
-   	is_false = 1
-   	is_true = 2
+   	is_false   = 1
+   	is_true    = 2
    }
 
 
@@ -351,7 +351,7 @@ struct VirtualTable
    pub struct VirtualTable {
    	create_table_sql  string
    	create_table_stmt CreateTableStmt
-   	data              VirtualTableProviderFn
+   	data              VirtualTableProviderFn [required]
    mut:
    	is_done bool
    	rows    []Row
@@ -413,7 +413,7 @@ struct Connection
    	// now allows you to override the wall clock that is used. The Time must be
    	// in UTC with a separate offset for the current local timezone (in positive
    	// or negative minutes).
-   	now fn () (time.Time, i16)
+   	now fn () (time.Time, i16) [required]
    	// warnings are SQLSTATE errors that do not stop the execution. For example,
    	// if a value must be truncated during a runtime CAST.
    	//

--- a/vsql/btree.v
+++ b/vsql/btree.v
@@ -272,7 +272,7 @@ fn (mut p Btree) split_page(path []int, page Page, obj PageObject, kind u8) ! {
 	mut inserted_at := -1
 	for pos, object in objects {
 		if compare_bytes(obj.key, object.key) <= 0 {
-			mut new_objects := objects[..pos]
+			mut new_objects := objects[..pos].clone()
 			new_objects << obj
 			new_objects << objects[pos..]
 			objects = new_objects.clone()
@@ -362,7 +362,7 @@ fn (mut p Btree) split_page(path []int, page Page, obj PageObject, kind u8) ! {
 		// usually quite small. However, they are not a fixed size because the
 		// keys can be variable length.
 		if page3.used > p.page_size - p2.length() {
-			mut new_path := path[..path.len - 1]
+			mut new_path := path[..path.len - 1].clone()
 			p.split_page(new_path, page3, p2, kind_not_leaf)!
 		} else {
 			page3.add(p2)!

--- a/vsql/btree_test.v
+++ b/vsql/btree_test.v
@@ -18,10 +18,10 @@ fn test_btree_test() ! {
 	blob_sizes := [
 		// 48 means all objects will fit in pages (and several per page) and
 		// never have to use blob storage.
-		48
+		48,
 		// 148 is larger than half a page so we always end up with one object
 		// per page, but no need to use blob storage, yet.
-		148
+		148,
 		// 348 is larger than a page so all items must go into blob storage.
 		348,
 	]

--- a/vsql/eval.v
+++ b/vsql/eval.v
@@ -293,7 +293,7 @@ fn time_value(conn &Connection, prec int, include_offset bool) string {
 	mut s := now.strftime('%H:%M:%S')
 
 	if prec > 0 {
-		microseconds := left_pad(now.microsecond.str(), '0', 6)
+		microseconds := left_pad(int(now.nanosecond / 1000).str(), '0', 6)
 		s += '.' + microseconds.substr(0, prec)
 	}
 

--- a/vsql/funcs.v
+++ b/vsql/funcs.v
@@ -6,7 +6,7 @@ struct Func {
 	name        string
 	arg_types   []Type
 	is_agg      bool
-	func        fn ([]Value) !Value
+	func        fn ([]Value) !Value [required]
 	return_type Type
 }
 

--- a/vsql/lexer.v
+++ b/vsql/lexer.v
@@ -35,9 +35,9 @@ pub:
 	value string
 }
 
-fn tokenize(sql string) []Token {
+fn tokenize(sql_stmt string) []Token {
 	mut tokens := []Token{}
-	cs := sql.trim(';').runes()
+	cs := sql_stmt.trim(';').runes()
 	mut i := 0
 
 	next: for i < cs.len {

--- a/vsql/pager.v
+++ b/vsql/pager.v
@@ -109,7 +109,7 @@ fn (mut p FilePager) fetch_page(page_number int) !Page {
 	return Page{
 		kind: b.read_u8()
 		used: b.read_u16()
-		data: buf[page_header_size..]
+		data: buf[page_header_size..].clone()
 	}
 }
 

--- a/vsql/query_cache.v
+++ b/vsql/query_cache.v
@@ -107,7 +107,7 @@ fn (mut q QueryCache) parse(query string) !(Stmt, map[string]Value, bool) {
 	mut explain := false
 	if tokens[0].value.to_upper() == 'EXPLAIN' {
 		explain = true
-		tokens = tokens[1..]
+		tokens = tokens[1..].clone()
 	}
 
 	key, params, new_tokens := q.prepare(tokens)

--- a/vsql/server.v
+++ b/vsql/server.v
@@ -34,6 +34,7 @@ pub fn new_server(options ServerOptions) Server {
 
 	return Server{options, &Connection{
 		query_cache: new_query_cache()
+		now: default_now
 		catalogs: {
 			catalog_name: catalog
 		}
@@ -95,7 +96,7 @@ fn (mut s Server) handle_conn(mut c net.TcpConn) ! {
 	for {
 		msg_type := conn.read_byte()!
 		match msg_type {
-			`Q` /* Query */ {
+			`Q` { // Query
 				mut query := conn.read_query()!
 
 				// A missing "FROM" clause is valid in PostgreSQL, but it's not
@@ -126,7 +127,7 @@ fn (mut s Server) handle_conn(mut c net.TcpConn) ! {
 
 				conn.write_ready_for_query()!
 			}
-			`X` /* Terminate */ {
+			`X` { // Terminate
 				// Don't bother consuming the message since we're going to
 				// disconnect anyway.
 				break

--- a/vsql/sql_test.v
+++ b/vsql/sql_test.v
@@ -138,7 +138,7 @@ fn run_single_test(test SQLTest, query_cache &QueryCache, verbose bool, filter_l
 			hour: 14
 			minute: 5
 			second: 3
-			microsecond: 120056
+			nanosecond: 120056000
 		}), 300
 	}
 	register_pg_functions(mut db)!

--- a/vsql/time.v
+++ b/vsql/time.v
@@ -154,7 +154,7 @@ fn new_time_from_components(typ Type, year int, month int, day int, hour int, mi
 		hour: hour
 		minute: minute
 		second: second
-		microsecond: microsecond
+		nanosecond: microsecond * 1000
 	})}
 }
 
@@ -237,7 +237,7 @@ fn (t Time) i64() i64 {
 // See i64() for details.
 fn (t Time) time_i64() i64 {
 	return t.t.hour * vsql.hour_period + t.t.minute * vsql.minute_period +
-		t.t.second * vsql.second_period + t.t.microsecond
+		t.t.second * vsql.second_period + int(t.t.nanosecond / 1000)
 }
 
 // See i64() for details.
@@ -312,7 +312,7 @@ fn (t Time) str_fractional_seconds(prec int) string {
 	}
 
 	// Round down first, if needed.
-	mut s := t.t.microsecond.str()
+	mut s := int(t.t.nanosecond / 1000).str()
 	if prec < s.len {
 		s = s[..prec]
 	}
@@ -391,4 +391,8 @@ fn time_zone_value(conn &Connection) string {
 	s += left_pad(int(offset / 60).str(), '0', 2) + ':' + left_pad(int(offset % 60).str(), '0', 2)
 
 	return s
+}
+
+fn default_now() (time.Time, i16) {
+	return time.utc(), i16(time.offset() / 60)
 }

--- a/vsql/utils.v
+++ b/vsql/utils.v
@@ -18,7 +18,7 @@ fn compare_bytes(a []u8, b []u8) int {
 
 	for i in 0 .. min {
 		if a[i] != b[i] {
-			return a[i] - b[i]
+			return int(a[i]) - int(b[i])
 		}
 	}
 

--- a/vsql/value.v
+++ b/vsql/value.v
@@ -12,8 +12,8 @@ import regex
 pub enum Boolean {
 	// These must not be negative values because they are encoded as u8 on disk.
 	is_unknown = 0 // same as NULL
-	is_false = 1
-	is_true = 2
+	is_false   = 1
+	is_true    = 2
 }
 
 // Returns ``TRUE``, ``FALSE`` or ``UNKNOWN``.

--- a/vsql/virtual_table.v
+++ b/vsql/virtual_table.v
@@ -6,7 +6,7 @@ type VirtualTableProviderFn = fn (mut t VirtualTable) !
 pub struct VirtualTable {
 	create_table_sql  string
 	create_table_stmt CreateTableStmt
-	data              VirtualTableProviderFn
+	data              VirtualTableProviderFn [required]
 mut:
 	is_done bool
 	rows    []Row

--- a/vsql/walk.v
+++ b/vsql/walk.v
@@ -33,7 +33,7 @@ fn (mut iter PageIterator) next() ?PageObject {
 
 		// Load all the objects for this leaf. Making sure to skip over any keys
 		// that are out of bounds.
-		iter.objects = (iter.btree.pager.fetch_page(iter.path[iter.path.len - 1])!).objects()
+		iter.objects = (iter.btree.pager.fetch_page(iter.path[iter.path.len - 1]) or { return none }).objects()
 		for object in iter.objects {
 			// TODO(elliotchance): It would be more efficient to do a binary
 			//  search here since the page is already sorted.
@@ -55,20 +55,22 @@ fn (mut iter PageIterator) next() ?PageObject {
 			iter.depth_iterator = iter.depth_iterator[..iter.depth_iterator.len - 1]
 			iter.depth_iterator[iter.depth_iterator.len - 1]++
 
-			if iter.depth_iterator[iter.depth_iterator.len - 1] < (iter.btree.pager.fetch_page(iter.path[iter.path.len - 1])!).objects().len {
+			if iter.depth_iterator[iter.depth_iterator.len - 1] < (iter.btree.pager.fetch_page(iter.path[iter.path.len - 1]) or {
+				return none
+			}).objects().len {
 				break
 			}
 		}
 
 		for (iter.btree.pager.fetch_page(iter.path[iter.path.len - 1])!).kind == kind_not_leaf {
-			objects := (iter.btree.pager.fetch_page(iter.path[iter.path.len - 1])!).objects()
+			objects := (iter.btree.pager.fetch_page(iter.path[iter.path.len - 1]) or { return none }).objects()
 
 			mut buf := new_bytes(objects[iter.depth_iterator[iter.depth_iterator.len - 1]].value)
 			iter.path << buf.read_i32()
 			iter.depth_iterator << 0
 		}
 
-		iter.objects = (iter.btree.pager.fetch_page(iter.path[iter.path.len - 1])!).objects()
+		iter.objects = (iter.btree.pager.fetch_page(iter.path[iter.path.len - 1]) or { return none }).objects()
 	}
 
 	o := iter.objects[iter.depth_iterator[iter.depth_iterator.len - 1]]


### PR DESCRIPTION
There are some minor syntax changes to bring it up to V 0.4.2 4bc9a8f. This also adds a new environment variable that lets you run tests at any version (tag or commit), such as:

    OLDV=0.3.5 make sql-test