### PR TITLE
chore: Refactor <predicate>

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,8 @@ clean-docs:
 
 # Grammar (BNF)
 
-grammar.bnf:
+grammar:
 	grep "//~" -r vsql | cut -d~ -f2 > grammar.bnf
-
-grammar: grammar.bnf
 	python3 generate-grammar.py
 	v fmt -w vsql/grammar.v
 

--- a/vsql/grammar.v
+++ b/vsql/grammar.v
@@ -4,7 +4,9 @@
 
 module vsql
 
-type EarleyValue = BetweenExpr
+type EarleyValue = BetweenPredicate
+	| CharacterLikePredicate
+	| ComparisonPredicate
 	| ComparisonPredicatePart2
 	| Correlation
 	| CreateTableStmt
@@ -13,7 +15,7 @@ type EarleyValue = BetweenExpr
 	| Identifier
 	| IdentifierChain
 	| InsertStmt
-	| LikeExpr
+	| NullPredicate
 	| QualifiedAsteriskExpr
 	| QualifiedJoin
 	| QueryExpression
@@ -24,7 +26,7 @@ type EarleyValue = BetweenExpr
 	| SequenceGeneratorOption
 	| SequenceGeneratorRestartOption
 	| SequenceGeneratorStartWithOption
-	| SimilarExpr
+	| SimilarPredicate
 	| SimpleTable
 	| SortSpecification
 	| Stmt
@@ -1087,6 +1089,21 @@ fn get_grammar() map[string]EarleyRule {
 	}
 	mut rule_predefined_type_ := &EarleyRule{
 		name: '<predefined type>'
+	}
+	mut rule_predicate_1_ := &EarleyRule{
+		name: '<predicate: 1>'
+	}
+	mut rule_predicate_2_ := &EarleyRule{
+		name: '<predicate: 2>'
+	}
+	mut rule_predicate_3_ := &EarleyRule{
+		name: '<predicate: 3>'
+	}
+	mut rule_predicate_4_ := &EarleyRule{
+		name: '<predicate: 4>'
+	}
+	mut rule_predicate_5_ := &EarleyRule{
+		name: '<predicate: 5>'
 	}
 	mut rule_predicate_ := &EarleyRule{
 		name: '<predicate>'
@@ -7965,29 +7982,59 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
-	rule_predicate_.productions << &EarleyProduction{[
+	rule_predicate_1_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_comparison_predicate_
 		},
 	]}
-	rule_predicate_.productions << &EarleyProduction{[
+
+	rule_predicate_2_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_between_predicate_
 		},
 	]}
-	rule_predicate_.productions << &EarleyProduction{[
+
+	rule_predicate_3_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_like_predicate_
 		},
 	]}
-	rule_predicate_.productions << &EarleyProduction{[
+
+	rule_predicate_4_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_similar_predicate_
 		},
 	]}
-	rule_predicate_.productions << &EarleyProduction{[
+
+	rule_predicate_5_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_null_predicate_
+		},
+	]}
+
+	rule_predicate_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_predicate_1_
+		},
+	]}
+	rule_predicate_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_predicate_2_
+		},
+	]}
+	rule_predicate_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_predicate_3_
+		},
+	]}
+	rule_predicate_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_predicate_4_
+		},
+	]}
+	rule_predicate_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_predicate_5_
 		},
 	]}
 
@@ -13356,6 +13403,11 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<power function>'] = rule_power_function_
 	rules['<precision>'] = rule_precision_
 	rules['<predefined type>'] = rule_predefined_type_
+	rules['<predicate: 1>'] = rule_predicate_1_
+	rules['<predicate: 2>'] = rule_predicate_2_
+	rules['<predicate: 3>'] = rule_predicate_3_
+	rules['<predicate: 4>'] = rule_predicate_4_
+	rules['<predicate: 5>'] = rule_predicate_5_
 	rules['<predicate>'] = rule_predicate_
 	rules['<preparable SQL data statement>'] = rule_preparable_sql_data_statement_
 	rules['<preparable SQL schema statement>'] = rule_preparable_sql_schema_statement_
@@ -14121,7 +14173,7 @@ fn parse_ast_name(children []EarleyValue, name string) ![]EarleyValue {
 		}
 		'<between predicate: 1>' {
 			return [
-				EarleyValue(parse_between(children[0] as Expr, children[1] as BetweenExpr)!),
+				EarleyValue(parse_between(children[0] as Expr, children[1] as BetweenPredicate)!),
 			]
 		}
 		'<boolean factor: 2>' {
@@ -14193,7 +14245,7 @@ fn parse_ast_name(children []EarleyValue, name string) ![]EarleyValue {
 		}
 		'<character like predicate: 1>' {
 			return [
-				EarleyValue(parse_like_pred(children[0] as Expr, children[1] as LikeExpr)!),
+				EarleyValue(parse_like_pred(children[0] as Expr, children[1] as CharacterLikePredicate)!),
 			]
 		}
 		'<character position expression: 1>' {
@@ -14665,6 +14717,25 @@ fn parse_ast_name(children []EarleyValue, name string) ![]EarleyValue {
 				EarleyValue(parse_power(children[2] as Expr, children[4] as Expr)!),
 			]
 		}
+		'<predicate: 1>' {
+			return [
+				EarleyValue(parse_predicate_1(children[0] as ComparisonPredicate)!),
+			]
+		}
+		'<predicate: 2>' {
+			return [EarleyValue(parse_predicate_2(children[0] as BetweenPredicate)!)]
+		}
+		'<predicate: 3>' {
+			return [
+				EarleyValue(parse_predicate_3(children[0] as CharacterLikePredicate)!),
+			]
+		}
+		'<predicate: 4>' {
+			return [EarleyValue(parse_predicate_4(children[0] as SimilarPredicate)!)]
+		}
+		'<predicate: 5>' {
+			return [EarleyValue(parse_predicate_5(children[0] as NullPredicate)!)]
+		}
 		'<qualified asterisk: 1>' {
 			return [
 				EarleyValue(parse_qualified_asterisk(children[0] as IdentifierChain, children[2] as string)!),
@@ -14880,7 +14951,7 @@ fn parse_ast_name(children []EarleyValue, name string) ![]EarleyValue {
 		}
 		'<similar predicate: 1>' {
 			return [
-				EarleyValue(parse_similar_pred(children[0] as Expr, children[1] as SimilarExpr)!),
+				EarleyValue(parse_similar_pred(children[0] as Expr, children[1] as SimilarPredicate)!),
 			]
 		}
 		'<sort specification list: 1>' {

--- a/vsql/planner.v
+++ b/vsql/planner.v
@@ -112,14 +112,16 @@ fn create_select_plan_without_join(body SelectStmt, from_clause TablePrimary, of
 				table = catalog.storage.tables[table_name_id]
 
 				// This is a special case to handle "PRIMARY KEY = INTEGER".
-				if table.primary_key.len > 0 && where is BinaryExpr {
-					left := where.left
-					right := where.right
-					if where.op == '=' && left is Identifier {
-						if left.sub_entity_name == table.primary_key[0] {
-							covered_by_pk = true
-							plan.operations << new_primary_key_operation(table, right,
-								right, params, c)
+				if table.primary_key.len > 0 && where is Predicate {
+					if where is ComparisonPredicate {
+						left := where.left
+						right := where.right
+						if where.op == '=' && left is Identifier {
+							if left.sub_entity_name == table.primary_key[0] {
+								covered_by_pk = true
+								plan.operations << new_primary_key_operation(table, right,
+									right, params, c)
+							}
 						}
 					}
 				}

--- a/vsql/std_between_predicate.v
+++ b/vsql/std_between_predicate.v
@@ -4,10 +4,10 @@ module vsql
 
 // Format
 //~
-//~ <between predicate> /* Expr */ ::=
+//~ <between predicate> /* BetweenPredicate */ ::=
 //~     <row value predicand> <between predicate part 2>   -> between
 //~
-//~ <between predicate part 2> /* BetweenExpr */ ::=
+//~ <between predicate part 2> /* BetweenPredicate */ ::=
 //~     <between predicate part 1>
 //~     <row value predicand> AND <row value predicand>   -> between1
 //~   | <between predicate part 1> <is symmetric>
@@ -23,8 +23,70 @@ module vsql
 //~     SYMMETRIC    -> yes
 //~   | ASYMMETRIC   -> no
 
-fn parse_between(expr Expr, between BetweenExpr) !Expr {
-	return BetweenExpr{
+struct BetweenPredicate {
+	not       bool
+	symmetric bool
+	expr      Expr
+	left      Expr
+	right     Expr
+}
+
+fn (e BetweenPredicate) pstr(params map[string]Value) string {
+	return '${e.expr.pstr(params)} ' + if e.not {
+		'NOT '
+	} else {
+		''
+	} + 'BETWEEN ' + if e.symmetric {
+		'SYMMETRIC '
+	} else {
+		''
+	} + '${e.left.pstr(params)} AND ${e.right.pstr(params)}'
+}
+
+fn (e BetweenPredicate) eval(mut conn Connection, data Row, params map[string]Value) !Value {
+	expr := eval_as_value(mut conn, data, e.expr, params)!
+	mut left := eval_as_value(mut conn, data, e.left, params)!
+	mut right := eval_as_value(mut conn, data, e.right, params)!
+
+	// SYMMETRIC operands might need to be swapped.
+	cmp := compare(left, right)!
+	if e.symmetric && cmp == .is_greater {
+		left, right = right, left
+	}
+
+	lower := compare(expr, left)!
+	upper := compare(expr, right)!
+
+	if lower == .is_unknown || upper == .is_unknown {
+		return new_unknown_value()
+	}
+
+	mut result := (lower == .is_greater || lower == .is_equal)
+		&& (upper == .is_less || upper == .is_equal)
+
+	if e.not {
+		result = !result
+	}
+
+	return new_boolean_value(result)
+}
+
+fn (e BetweenPredicate) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
+	if expr_is_agg(conn, e.left, row, params)! || expr_is_agg(conn, e.right, row, params)! {
+		return nested_agg_unsupported(Predicate(e))
+	}
+
+	return false
+}
+
+fn (e BetweenPredicate) resolve_identifiers(conn &Connection, tables map[string]Table) !Expr {
+	return Predicate(BetweenPredicate{e.not, e.symmetric, resolve_identifiers(conn, e.expr,
+		tables)!, resolve_identifiers(conn, e.left, tables)!, resolve_identifiers(conn,
+		e.right, tables)!})
+}
+
+fn parse_between(expr Expr, between BetweenPredicate) !BetweenPredicate {
+	return BetweenPredicate{
 		not: between.not
 		symmetric: between.symmetric
 		expr: expr
@@ -33,13 +95,13 @@ fn parse_between(expr Expr, between BetweenExpr) !Expr {
 	}
 }
 
-fn parse_between1(is_true bool, left Expr, right Expr) !BetweenExpr {
+fn parse_between1(is_true bool, left Expr, right Expr) !BetweenPredicate {
 	// false between ASYMMETRIC by default.
 	return parse_between2(is_true, false, left, right)
 }
 
-fn parse_between2(is_true bool, symmetric bool, left Expr, right Expr) !BetweenExpr {
-	return BetweenExpr{
+fn parse_between2(is_true bool, symmetric bool, left Expr, right Expr) !BetweenPredicate {
+	return BetweenPredicate{
 		not: !is_true
 		symmetric: symmetric
 		left: left

--- a/vsql/std_comparison_predicate.v
+++ b/vsql/std_comparison_predicate.v
@@ -4,7 +4,7 @@ module vsql
 
 // Format
 //~
-//~ <comparison predicate> /* Expr */ ::=
+//~ <comparison predicate> /* ComparisonPredicate */ ::=
 //~     <row value predicand> <comparison predicate part 2>   -> comparison
 //~
 //~ <comparison predicate part 2> /* ComparisonPredicatePart2 */ ::=
@@ -18,10 +18,73 @@ module vsql
 //~   | <less than or equals operator>
 //~   | <greater than or equals operator>
 
+struct ComparisonPredicate {
+	left  Expr
+	op    string
+	right Expr
+}
+
+fn (e ComparisonPredicate) pstr(params map[string]Value) string {
+	return '${e.left.pstr(params)} ${e.op} ${e.right.pstr(params)}'
+}
+
+fn (e ComparisonPredicate) eval(mut conn Connection, data Row, params map[string]Value) !Value {
+	mut left := eval_as_value(mut conn, data, e.left, params)!
+	mut right := eval_as_value(mut conn, data, e.right, params)!
+
+	cmp := compare(left, right)!
+	if cmp == .is_unknown {
+		return new_unknown_value()
+	}
+
+	return new_boolean_value(match e.op {
+		'=' {
+			cmp == .is_equal
+		}
+		'<>' {
+			cmp != .is_equal
+		}
+		'>' {
+			cmp == .is_greater
+		}
+		'<' {
+			cmp == .is_less
+		}
+		'>=' {
+			cmp == .is_greater || cmp == .is_equal
+		}
+		'<=' {
+			cmp == .is_less || cmp == .is_equal
+		}
+		else {
+			// This should not be possible, but it's to satisfy the required else.
+			panic('invalid binary operator: ${e.op}')
+		}
+	})
+}
+
+fn (e ComparisonPredicate) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
+	if expr_is_agg(conn, e.left, row, params)! || expr_is_agg(conn, e.right, row, params)! {
+		return nested_agg_unsupported(Predicate(e))
+	}
+
+	return false
+}
+
+fn (e ComparisonPredicate) resolve_identifiers(conn &Connection, tables map[string]Table) !Expr {
+	return Predicate(ComparisonPredicate{resolve_identifiers(conn, e.left, tables)!, e.op, resolve_identifiers(conn,
+		e.right, tables)!})
+}
+
+struct ComparisonPredicatePart2 {
+	op   string
+	expr Expr
+}
+
 fn parse_comparison_part(op string, expr Expr) !ComparisonPredicatePart2 {
 	return ComparisonPredicatePart2{op, expr}
 }
 
-fn parse_comparison(expr Expr, comp ComparisonPredicatePart2) !Expr {
-	return BinaryExpr{expr, comp.op, comp.expr}
+fn parse_comparison(expr Expr, comp ComparisonPredicatePart2) !ComparisonPredicate {
+	return ComparisonPredicate{expr, comp.op, comp.expr}
 }

--- a/vsql/std_like_predicate.v
+++ b/vsql/std_like_predicate.v
@@ -2,29 +2,81 @@
 
 module vsql
 
+import regex
+
 // Format
 //~
-//~ <like predicate> /* Expr */ ::=
+//~ <like predicate> /* CharacterLikePredicate */ ::=
 //~     <character like predicate>
 //~
-//~ <character like predicate> /* Expr */ ::=
+//~ <character like predicate> /* CharacterLikePredicate */ ::=
 //~     <row value predicand> <character like predicate part 2>   -> like_pred
 //~
-//~ <character like predicate part 2> /* LikeExpr */ ::=
+//~ <character like predicate part 2> /* CharacterLikePredicate */ ::=
 //~     LIKE <character pattern>       -> like
 //~   | NOT LIKE <character pattern>   -> not_like
 //~
 //~ <character pattern> /* Expr */ ::=
 //~     <character value expression>
 
-fn parse_like_pred(left Expr, like LikeExpr) !Expr {
-	return LikeExpr{left, like.right, like.not}
+// CharacterLikePredicate for "LIKE" and "NOT LIKE".
+struct CharacterLikePredicate {
+	left  Expr
+	right Expr
+	not   bool
 }
 
-fn parse_like(expr Expr) !LikeExpr {
-	return LikeExpr{NoExpr{}, expr, false}
+fn (e CharacterLikePredicate) pstr(params map[string]Value) string {
+	if e.not {
+		return '${e.left.pstr(params)} NOT LIKE ${e.right.pstr(params)}'
+	}
+
+	return '${e.left.pstr(params)} LIKE ${e.right.pstr(params)}'
 }
 
-fn parse_not_like(expr Expr) !LikeExpr {
-	return LikeExpr{NoExpr{}, expr, true}
+fn (e CharacterLikePredicate) eval(mut conn Connection, data Row, params map[string]Value) !Value {
+	left := eval_as_value(mut conn, data, e.left, params)!
+	right := eval_as_value(mut conn, data, e.right, params)!
+
+	// Make sure we escape any regexp characters.
+	escaped_regex := right.string_value().replace('+', '\\+').replace('?', '\\?').replace('*',
+		'\\*').replace('|', '\\|').replace('.', '\\.').replace('(', '\\(').replace(')',
+		'\\)').replace('[', '\\[').replace('{', '\\{').replace('_', '.').replace('%',
+		'.*')
+
+	mut re := regex.regex_opt('^${escaped_regex}$') or {
+		return error('cannot compile regexp: ^${escaped_regex}$: ${err}')
+	}
+	result := re.matches_string(left.string_value())
+
+	if e.not {
+		return new_boolean_value(!result)
+	}
+
+	return new_boolean_value(result)
+}
+
+fn (e CharacterLikePredicate) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
+	if expr_is_agg(conn, e.left, row, params)! {
+		return nested_agg_unsupported(Predicate(e))
+	}
+
+	return false
+}
+
+fn (e CharacterLikePredicate) resolve_identifiers(conn &Connection, tables map[string]Table) !Expr {
+	return Predicate(CharacterLikePredicate{resolve_identifiers(conn, e.left, tables)!, resolve_identifiers(conn,
+		e.right, tables)!, e.not})
+}
+
+fn parse_like_pred(left Expr, like CharacterLikePredicate) !CharacterLikePredicate {
+	return CharacterLikePredicate{left, like.right, like.not}
+}
+
+fn parse_like(expr Expr) !CharacterLikePredicate {
+	return CharacterLikePredicate{NoExpr{}, expr, false}
+}
+
+fn parse_not_like(expr Expr) !CharacterLikePredicate {
+	return CharacterLikePredicate{NoExpr{}, expr, true}
 }

--- a/vsql/std_null_predicate.v
+++ b/vsql/std_null_predicate.v
@@ -4,13 +4,49 @@ module vsql
 
 // Format
 //~
-//~ <null predicate> /* Expr */ ::=
+//~ <null predicate> /* NullPredicate */ ::=
 //~     <row value predicand> <null predicate part 2>   -> null_predicate
 //~
 //~ <null predicate part 2> /* bool */ ::=
 //~     IS NULL       -> yes
 //~   | IS NOT NULL   -> no
 
-fn parse_null_predicate(expr Expr, is_null bool) !Expr {
-	return NullExpr{expr, !is_null}
+// NullPredicate for "IS NULL" and "IS NOT NULL".
+struct NullPredicate {
+	expr Expr
+	not  bool
+}
+
+fn (e NullPredicate) pstr(params map[string]Value) string {
+	if e.not {
+		return '${e.expr.pstr(params)} IS NOT NULL'
+	}
+
+	return '${e.expr.pstr(params)} IS NULL'
+}
+
+fn (e NullPredicate) eval(mut conn Connection, data Row, params map[string]Value) !Value {
+	value := eval_as_value(mut conn, data, e.expr, params)!
+
+	if e.not {
+		return new_boolean_value(!value.is_null)
+	}
+
+	return new_boolean_value(value.is_null)
+}
+
+fn (e NullPredicate) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
+	if expr_is_agg(conn, e.expr, row, params)! {
+		return nested_agg_unsupported(Predicate(e))
+	}
+
+	return false
+}
+
+fn (e NullPredicate) resolve_identifiers(conn &Connection, tables map[string]Table) !Expr {
+	return Predicate(NullPredicate{resolve_identifiers(conn, e.expr, tables)!, e.not})
+}
+
+fn parse_null_predicate(expr Expr, is_null bool) !NullPredicate {
+	return NullPredicate{expr, !is_null}
 }

--- a/vsql/std_predicate.v
+++ b/vsql/std_predicate.v
@@ -5,8 +5,75 @@ module vsql
 // Format
 //~
 //~ <predicate> /* Expr */ ::=
-//~     <comparison predicate>
-//~   | <between predicate>
-//~   | <like predicate>
-//~   | <similar predicate>
-//~   | <null predicate>
+//~     <comparison predicate>   -> predicate_1
+//~   | <between predicate>      -> predicate_2
+//~   | <like predicate>         -> predicate_3
+//~   | <similar predicate>      -> predicate_4
+//~   | <null predicate>         -> predicate_5
+
+type Predicate = BetweenPredicate
+	| CharacterLikePredicate
+	| ComparisonPredicate
+	| NullPredicate
+	| SimilarPredicate
+
+fn (e Predicate) pstr(params map[string]Value) string {
+	return match e {
+		ComparisonPredicate, BetweenPredicate, CharacterLikePredicate, SimilarPredicate,
+		NullPredicate {
+			e.pstr(params)
+		}
+	}
+}
+
+fn (e Predicate) eval(mut conn Connection, data Row, params map[string]Value) !Value {
+	return match e {
+		ComparisonPredicate, BetweenPredicate, CharacterLikePredicate, SimilarPredicate,
+		NullPredicate {
+			e.eval(mut conn, data, params)!
+		}
+	}
+}
+
+fn (e Predicate) eval_type(conn &Connection, data Row, params map[string]Value) !Type {
+	// The result of a predicate is always a BOOLEAN.
+	return new_type('BOOLEAN', 0, 0)
+}
+
+fn (e Predicate) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
+	return match e {
+		ComparisonPredicate, BetweenPredicate, CharacterLikePredicate, SimilarPredicate,
+		NullPredicate {
+			e.is_agg(conn, row, params)!
+		}
+	}
+}
+
+fn (e Predicate) resolve_identifiers(conn &Connection, tables map[string]Table) !Expr {
+	return match e {
+		ComparisonPredicate, BetweenPredicate, CharacterLikePredicate, SimilarPredicate,
+		NullPredicate {
+			e.resolve_identifiers(conn, tables)!
+		}
+	}
+}
+
+fn parse_predicate_1(predicate ComparisonPredicate) !Expr {
+	return Predicate(predicate)
+}
+
+fn parse_predicate_2(predicate BetweenPredicate) !Expr {
+	return Predicate(predicate)
+}
+
+fn parse_predicate_3(predicate CharacterLikePredicate) !Expr {
+	return Predicate(predicate)
+}
+
+fn parse_predicate_4(predicate SimilarPredicate) !Expr {
+	return Predicate(predicate)
+}
+
+fn parse_predicate_5(predicate NullPredicate) !Expr {
+	return Predicate(predicate)
+}

--- a/vsql/std_similar_predicate.v
+++ b/vsql/std_similar_predicate.v
@@ -2,26 +2,74 @@
 
 module vsql
 
+import regex
+
 // Format
 //~
-//~ <similar predicate> /* Expr */ ::=
+//~ <similar predicate> /* SimilarPredicate */ ::=
 //~     <row value predicand> <similar predicate part 2>   -> similar_pred
 //~
-//~ <similar predicate part 2> /* SimilarExpr */ ::=
+//~ <similar predicate part 2> /* SimilarPredicate */ ::=
 //~     SIMILAR TO <similar pattern>       -> similar
 //~   | NOT SIMILAR TO <similar pattern>   -> not_similar
 //~
 //~ <similar pattern> /* Expr */ ::=
 //~     <character value expression>
 
-fn parse_similar_pred(left Expr, like SimilarExpr) !Expr {
-	return SimilarExpr{left, like.right, like.not}
+// SimilarPredicate for "SIMILAR TO" and "NOT SIMILAR TO".
+struct SimilarPredicate {
+	left  Expr
+	right Expr
+	not   bool
 }
 
-fn parse_similar(expr Expr) !SimilarExpr {
-	return SimilarExpr{NoExpr{}, expr, false}
+fn (e SimilarPredicate) pstr(params map[string]Value) string {
+	if e.not {
+		return '${e.left.pstr(params)} NOT SIMILAR TO ${e.right.pstr(params)}'
+	}
+
+	return '${e.left.pstr(params)} SIMILAR TO ${e.right.pstr(params)}'
 }
 
-fn parse_not_similar(expr Expr) !SimilarExpr {
-	return SimilarExpr{NoExpr{}, expr, true}
+fn (e SimilarPredicate) eval(mut conn Connection, data Row, params map[string]Value) !Value {
+	left := eval_as_value(mut conn, data, e.left, params)!
+	right := eval_as_value(mut conn, data, e.right, params)!
+
+	regexp := '^${right.string_value().replace('.', '\\.').replace('_', '.').replace('%',
+		'.*')}$'
+	mut re := regex.regex_opt(regexp) or {
+		return error('cannot compile regexp: ${regexp}: ${err}')
+	}
+	result := re.matches_string(left.string_value())
+
+	if e.not {
+		return new_boolean_value(!result)
+	}
+
+	return new_boolean_value(result)
+}
+
+fn (e SimilarPredicate) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
+	if expr_is_agg(conn, e.left, row, params)! {
+		return nested_agg_unsupported(Predicate(e))
+	}
+
+	return false
+}
+
+fn (e SimilarPredicate) resolve_identifiers(conn &Connection, tables map[string]Table) !Expr {
+	return Predicate(SimilarPredicate{resolve_identifiers(conn, e.left, tables)!, resolve_identifiers(conn,
+		e.right, tables)!, e.not})
+}
+
+fn parse_similar_pred(left Expr, like SimilarPredicate) !SimilarPredicate {
+	return SimilarPredicate{left, like.right, like.not}
+}
+
+fn parse_similar(expr Expr) !SimilarPredicate {
+	return SimilarPredicate{NoExpr{}, expr, false}
+}
+
+fn parse_not_similar(expr Expr) !SimilarPredicate {
+	return SimilarPredicate{NoExpr{}, expr, true}
 }


### PR DESCRIPTION
As a longer term effort to remove ast.v and eval.v, this moves <predicate> and its subtypes into their respective locations.

This also fixes a bug where the Makefile will no regenerate the grammar.bnf.