### PR TITLE
chore: Refactor <unsigned value specification>

### DIFF
--- a/vsql/expr.v
+++ b/vsql/expr.v
@@ -12,7 +12,7 @@ fn expr_is_agg(conn &Connection, e Expr, row Row, params map[string]Value) !bool
 				return nested_agg_unsupported(e)
 			}
 		}
-		Predicate {
+		Predicate, UnsignedValueSpecification {
 			return e.is_agg(conn, row, params)
 		}
 		CallExpr {
@@ -36,9 +36,9 @@ fn expr_is_agg(conn &Connection, e Expr, row Row, params map[string]Value) !bool
 		CountAllExpr {
 			return true
 		}
-		Identifier, Parameter, Value, NoExpr, RowExpr, QualifiedAsteriskExpr, QueryExpression,
+		Identifier, Value, NoExpr, RowExpr, QualifiedAsteriskExpr, QueryExpression,
 		CurrentDateExpr, CurrentTimeExpr, CurrentTimestampExpr, LocalTimeExpr, LocalTimestampExpr,
-		UntypedNullExpr, NextValueExpr, CurrentCatalogExpr, CurrentSchemaExpr {
+		UntypedNullExpr, NextValueExpr {
 			return false
 		}
 		CoalesceExpr {
@@ -107,7 +107,7 @@ fn resolve_identifiers(conn &Connection, e Expr, tables map[string]Table) !Expr 
 			return BinaryExpr{resolve_identifiers(conn, e.left, tables)!, e.op, resolve_identifiers(conn,
 				e.right, tables)!}
 		}
-		Predicate {
+		Predicate, UnsignedValueSpecification {
 			return e.resolve_identifiers(conn, tables)
 		}
 		CallExpr {
@@ -159,9 +159,8 @@ fn resolve_identifiers(conn &Connection, e Expr, tables map[string]Table) !Expr 
 		QualifiedAsteriskExpr {
 			return QualifiedAsteriskExpr{resolve_identifiers(conn, e.table_name, tables)! as Identifier}
 		}
-		CountAllExpr, Parameter, Value, NoExpr, QueryExpression, CurrentDateExpr, CurrentTimeExpr,
-		CurrentTimestampExpr, LocalTimeExpr, LocalTimestampExpr, UntypedNullExpr,
-		CurrentSchemaExpr, CurrentCatalogExpr {
+		CountAllExpr, Value, NoExpr, QueryExpression, CurrentDateExpr, CurrentTimeExpr,
+		CurrentTimestampExpr, LocalTimeExpr, LocalTimestampExpr, UntypedNullExpr {
 			// These don't have any Expr properties to recurse.
 			return e
 		}

--- a/vsql/grammar.v
+++ b/vsql/grammar.v
@@ -12,6 +12,7 @@ type EarleyValue = BetweenPredicate
 	| CreateTableStmt
 	| DerivedColumn
 	| Expr
+	| GeneralValueSpecification
 	| Identifier
 	| IdentifierChain
 	| InsertStmt
@@ -36,6 +37,7 @@ type EarleyValue = BetweenPredicate
 	| TablePrimaryBody
 	| TableReference
 	| Type
+	| UnsignedValueSpecification
 	| Value
 	| []Expr
 	| []Identifier
@@ -958,6 +960,9 @@ fn get_grammar() map[string]EarleyRule {
 	mut rule_non_reserved_word_ := &EarleyRule{
 		name: '<non-reserved word>'
 	}
+	mut rule_nonparenthesized_value_expression_primary_1_ := &EarleyRule{
+		name: '<nonparenthesized value expression primary: 1>'
+	}
 	mut rule_nonparenthesized_value_expression_primary_2_ := &EarleyRule{
 		name: '<nonparenthesized value expression primary: 2>'
 	}
@@ -1444,6 +1449,9 @@ fn get_grammar() map[string]EarleyRule {
 	mut rule_simple_table_ := &EarleyRule{
 		name: '<simple table>'
 	}
+	mut rule_simple_value_specification_2_ := &EarleyRule{
+		name: '<simple value specification: 2>'
+	}
 	mut rule_simple_value_specification_ := &EarleyRule{
 		name: '<simple value specification>'
 	}
@@ -1753,6 +1761,9 @@ fn get_grammar() map[string]EarleyRule {
 	mut rule_unsigned_value_specification_1_ := &EarleyRule{
 		name: '<unsigned value specification: 1>'
 	}
+	mut rule_unsigned_value_specification_2_ := &EarleyRule{
+		name: '<unsigned value specification: 2>'
+	}
 	mut rule_unsigned_value_specification_ := &EarleyRule{
 		name: '<unsigned value specification>'
 	}
@@ -1785,6 +1796,9 @@ fn get_grammar() map[string]EarleyRule {
 	}
 	mut rule_value_expression_ := &EarleyRule{
 		name: '<value expression>'
+	}
+	mut rule_value_specification_2_ := &EarleyRule{
+		name: '<value specification: 2>'
 	}
 	mut rule_value_specification_ := &EarleyRule{
 		name: '<value specification>'
@@ -7508,6 +7522,12 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
+	rule_nonparenthesized_value_expression_primary_1_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_unsigned_value_specification_
+		},
+	]}
+
 	rule_nonparenthesized_value_expression_primary_2_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_column_reference_
@@ -7516,7 +7536,7 @@ fn get_grammar() map[string]EarleyRule {
 
 	rule_nonparenthesized_value_expression_primary_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
-			rule: rule_unsigned_value_specification_
+			rule: rule_nonparenthesized_value_expression_primary_1_
 		},
 	]}
 	rule_nonparenthesized_value_expression_primary_.productions << &EarleyProduction{[
@@ -9100,6 +9120,12 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
+	rule_simple_value_specification_2_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_host_parameter_name_
+		},
+	]}
+
 	rule_simple_value_specification_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_literal_
@@ -9107,7 +9133,7 @@ fn get_grammar() map[string]EarleyRule {
 	]}
 	rule_simple_value_specification_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
-			rule: rule_host_parameter_name_
+			rule: rule_simple_value_specification_2_
 		},
 	]}
 
@@ -10083,6 +10109,12 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
+	rule_unsigned_value_specification_2_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_general_value_specification_
+		},
+	]}
+
 	rule_unsigned_value_specification_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_unsigned_value_specification_1_
@@ -10090,7 +10122,7 @@ fn get_grammar() map[string]EarleyRule {
 	]}
 	rule_unsigned_value_specification_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
-			rule: rule_general_value_specification_
+			rule: rule_unsigned_value_specification_2_
 		},
 	]}
 
@@ -10209,6 +10241,12 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
+	rule_value_specification_2_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_general_value_specification_
+		},
+	]}
+
 	rule_value_specification_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_literal_
@@ -10216,7 +10254,7 @@ fn get_grammar() map[string]EarleyRule {
 	]}
 	rule_value_specification_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
-			rule: rule_general_value_specification_
+			rule: rule_value_specification_2_
 		},
 	]}
 
@@ -13359,6 +13397,7 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<next value expression: 1>'] = rule_next_value_expression_1_
 	rules['<next value expression>'] = rule_next_value_expression_
 	rules['<non-reserved word>'] = rule_non_reserved_word_
+	rules['<nonparenthesized value expression primary: 1>'] = rule_nonparenthesized_value_expression_primary_1_
 	rules['<nonparenthesized value expression primary: 2>'] = rule_nonparenthesized_value_expression_primary_2_
 	rules['<nonparenthesized value expression primary>'] = rule_nonparenthesized_value_expression_primary_
 	rules['<not equals operator>'] = rule_not_equals_operator_
@@ -13521,6 +13560,7 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<similar predicate: 1>'] = rule_similar_predicate_1_
 	rules['<similar predicate>'] = rule_similar_predicate_
 	rules['<simple table>'] = rule_simple_table_
+	rules['<simple value specification: 2>'] = rule_simple_value_specification_2_
 	rules['<simple value specification>'] = rule_simple_value_specification_
 	rules['<solidus>'] = rule_solidus_
 	rules['<sort key>'] = rule_sort_key_
@@ -13624,6 +13664,7 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<unsigned literal>'] = rule_unsigned_literal_
 	rules['<unsigned numeric literal>'] = rule_unsigned_numeric_literal_
 	rules['<unsigned value specification: 1>'] = rule_unsigned_value_specification_1_
+	rules['<unsigned value specification: 2>'] = rule_unsigned_value_specification_2_
 	rules['<unsigned value specification>'] = rule_unsigned_value_specification_
 	rules['<update source>'] = rule_update_source_
 	rules['<update statement: searched: 1>'] = rule_update_statement_searched_1_
@@ -13635,6 +13676,7 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<value expression list>'] = rule_value_expression_list_
 	rules['<value expression primary>'] = rule_value_expression_primary_
 	rules['<value expression>'] = rule_value_expression_
+	rules['<value specification: 2>'] = rule_value_specification_2_
 	rules['<value specification>'] = rule_value_specification_
 	rules['<where clause: 1>'] = rule_where_clause_1_
 	rules['<where clause>'] = rule_where_clause_
@@ -14658,6 +14700,11 @@ fn parse_ast_name(children []EarleyValue, name string) ![]EarleyValue {
 				EarleyValue(parse_next_value_expression(children[3] as Identifier)!),
 			]
 		}
+		'<nonparenthesized value expression primary: 1>' {
+			return [
+				EarleyValue(parse_nonparenthesized_value_expression_primary_1(children[0] as UnsignedValueSpecification)!),
+			]
+		}
 		'<nonparenthesized value expression primary: 2>' {
 			return [
 				EarleyValue(parse_identifier_to_expr(children[0] as Identifier)!),
@@ -14954,6 +15001,11 @@ fn parse_ast_name(children []EarleyValue, name string) ![]EarleyValue {
 				EarleyValue(parse_similar_pred(children[0] as Expr, children[1] as SimilarPredicate)!),
 			]
 		}
+		'<simple value specification: 2>' {
+			return [
+				EarleyValue(parse_simple_value_specification_2(children[0] as GeneralValueSpecification)!),
+			]
+		}
 		'<sort specification list: 1>' {
 			return [EarleyValue(parse_sort_list1(children[0] as SortSpecification)!)]
 		}
@@ -15131,7 +15183,14 @@ fn parse_ast_name(children []EarleyValue, name string) ![]EarleyValue {
 			]
 		}
 		'<unsigned value specification: 1>' {
-			return [EarleyValue(parse_value_to_expr(children[0] as Value)!)]
+			return [
+				EarleyValue(parse_unsigned_value_specification_1(children[0] as Value)!),
+			]
+		}
+		'<unsigned value specification: 2>' {
+			return [
+				EarleyValue(parse_unsigned_value_specification_2(children[0] as GeneralValueSpecification)!),
+			]
 		}
 		'<update statement: searched: 1>' {
 			return [
@@ -15150,6 +15209,11 @@ fn parse_ast_name(children []EarleyValue, name string) ![]EarleyValue {
 		'<value expression list: 2>' {
 			return [
 				EarleyValue(parse_append_exprs1(children[0] as []Expr, children[2] as Expr)!),
+			]
+		}
+		'<value specification: 2>' {
+			return [
+				EarleyValue(parse_value_specification_2(children[0] as GeneralValueSpecification)!),
 			]
 		}
 		'<where clause: 1>' {

--- a/vsql/std_literal.v
+++ b/vsql/std_literal.v
@@ -91,3 +91,7 @@ fn parse_time_literal(v Value) !Value {
 fn parse_timestamp_literal(v Value) !Value {
 	return new_timestamp_value(v.string_value())
 }
+
+fn parse_value_to_expr(v Value) !Expr {
+	return v
+}

--- a/vsql/std_value_expression_primary.v
+++ b/vsql/std_value_expression_primary.v
@@ -12,7 +12,7 @@ module vsql
 //~     <left paren> <value expression> <right paren>   -> expr
 //~
 //~ <nonparenthesized value expression primary> /* Expr */ ::=
-//~     <unsigned value specification>
+//~     <unsigned value specification>   -> nonparenthesized_value_expression_primary_1
 //~   | <column reference>               -> identifier_to_expr
 //~   | <set function specification>
 //~   | <routine invocation>
@@ -26,4 +26,8 @@ fn parse_expr(e Expr) !Expr {
 
 fn parse_identifier_to_expr(name Identifier) !Expr {
 	return name
+}
+
+fn parse_nonparenthesized_value_expression_primary_1(e UnsignedValueSpecification) !Expr {
+	return e
 }

--- a/vsql/std_value_specification_and_target_specification.v
+++ b/vsql/std_value_specification_and_target_specification.v
@@ -6,32 +6,107 @@ module vsql
 //~
 //~ <value specification> /* Expr */ ::=
 //~     <literal>
-//~   | <general value specification>
+//~   | <general value specification>   -> value_specification_2
 //~
-//~ <unsigned value specification> /* Expr */ ::=
-//~     <unsigned literal>              -> value_to_expr
-//~   | <general value specification>
+//~ <unsigned value specification> /* UnsignedValueSpecification */ ::=
+//~     <unsigned literal>              -> unsigned_value_specification_1
+//~   | <general value specification>   -> unsigned_value_specification_2
 //~
-//~ <general value specification> /* Expr */ ::=
+//~ <general value specification> /* GeneralValueSpecification */ ::=
 //~     <host parameter specification>
 //~   | CURRENT_CATALOG                  -> current_catalog
 //~   | CURRENT_SCHEMA                   -> current_schema
 //~
 //~ <simple value specification> /* Expr */ ::=
 //~     <literal>
-//~   | <host parameter name>
+//~   | <host parameter name>   -> simple_value_specification_2
 //~
-//~ <host parameter specification> /* Expr */ ::=
+//~ <host parameter specification> /* GeneralValueSpecification */ ::=
 //~     <host parameter name>
 
-fn parse_current_catalog() !Expr {
-	return CurrentCatalogExpr{}
+type UnsignedValueSpecification = GeneralValueSpecification | Value
+
+fn (e UnsignedValueSpecification) pstr(params map[string]Value) string {
+	return match e {
+		Value, GeneralValueSpecification { e.pstr(params) }
+	}
 }
 
-fn parse_current_schema() !Expr {
-	return CurrentSchemaExpr{}
+fn (e UnsignedValueSpecification) eval_type(conn &Connection, data Row, params map[string]Value) !Type {
+	return match e {
+		Value { eval_as_type(conn, data, e, params)! }
+		GeneralValueSpecification { e.eval_type(conn, data, params)! }
+	}
 }
 
-fn parse_value_to_expr(v Value) !Expr {
+fn (e UnsignedValueSpecification) eval(mut conn Connection, data Row, params map[string]Value) !Value {
+	return match e {
+		Value { eval_as_value(mut conn, data, e, params)! }
+		GeneralValueSpecification { e.eval(mut conn, data, params)! }
+	}
+}
+
+fn (e UnsignedValueSpecification) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
+	return false
+}
+
+fn (e UnsignedValueSpecification) resolve_identifiers(conn &Connection, tables map[string]Table) !Expr {
+	return e
+}
+
+type GeneralValueSpecification = CurrentCatalog | CurrentSchema | HostParameterName
+
+// CURRENT_CATALOG
+struct CurrentCatalog {
+}
+
+// CURRENT_SCHEMA
+struct CurrentSchema {
+}
+
+fn (e GeneralValueSpecification) pstr(params map[string]Value) string {
+	return match e {
+		HostParameterName { e.pstr(params) }
+		CurrentCatalog { 'CURRENT_CATALOG' }
+		CurrentSchema { 'CURRENT_SCHEMA' }
+	}
+}
+
+fn (e GeneralValueSpecification) eval_type(conn &Connection, data Row, params map[string]Value) !Type {
+	return match e {
+		HostParameterName { e.eval_type(conn, data, params)! }
+		CurrentCatalog, CurrentSchema { new_type('CHARACTER VARYING', 0, 0) }
+	}
+}
+
+fn (e GeneralValueSpecification) eval(mut conn Connection, data Row, params map[string]Value) !Value {
+	return match e {
+		HostParameterName { e.eval(mut conn, data, params)! }
+		CurrentCatalog { new_varchar_value(conn.current_catalog) }
+		CurrentSchema { new_varchar_value(conn.current_schema) }
+	}
+}
+
+fn parse_current_catalog() !GeneralValueSpecification {
+	return CurrentCatalog{}
+}
+
+fn parse_current_schema() !GeneralValueSpecification {
+	return CurrentSchema{}
+}
+
+fn parse_unsigned_value_specification_1(v Value) !UnsignedValueSpecification {
 	return v
+}
+
+fn parse_unsigned_value_specification_2(v GeneralValueSpecification) !UnsignedValueSpecification {
+	return v
+}
+
+fn parse_value_specification_2(e GeneralValueSpecification) !Expr {
+	return UnsignedValueSpecification(e)
+}
+
+fn parse_simple_value_specification_2(e GeneralValueSpecification) !Expr {
+	return UnsignedValueSpecification(e)
 }

--- a/vsql/value.v
+++ b/vsql/value.v
@@ -286,6 +286,14 @@ fn (v Value) as_numeric() !big.Integer {
 	return big.integer_from_string(strconv.f64_to_str_l(v.f64_value()).split('.')[0])
 }
 
+fn (v Value) pstr(params map[string]Value) string {
+	if v.typ.typ != .is_numeric && (v.typ.uses_string() || v.typ.uses_time()) {
+		return '\'${v.str()}\''
+	}
+
+	return v.str()
+}
+
 // The string representation of this value. Different types will have different
 // formatting.
 pub fn (v Value) str() string {


### PR DESCRIPTION
As a longer term effort to remove ast.v and eval.v, this moves <unsigned value specification> and its subtypes into their respective locations.