### PR TITLE
chore: Refactor <datetime value function>

### DIFF
--- a/vsql/ast.v
+++ b/vsql/ast.v
@@ -28,12 +28,8 @@ type Expr = BinaryExpr
 	| CastExpr
 	| CoalesceExpr
 	| CountAllExpr
-	| CurrentDateExpr
-	| CurrentTimeExpr
-	| CurrentTimestampExpr
+	| DatetimeValueFunction
 	| Identifier
-	| LocalTimeExpr
-	| LocalTimestampExpr
 	| NextValueExpr
 	| NoExpr
 	| NullIfExpr
@@ -55,7 +51,7 @@ fn (e Expr) str() string {
 
 fn (e Expr) pstr(params map[string]Value) string {
 	return match e {
-		Predicate, UnsignedValueSpecification {
+		Predicate, UnsignedValueSpecification, DatetimeValueFunction {
 			e.pstr(params)
 		}
 		BinaryExpr {
@@ -73,22 +69,7 @@ fn (e Expr) pstr(params map[string]Value) string {
 		CountAllExpr {
 			e.pstr(params)
 		}
-		CurrentDateExpr {
-			e.str()
-		}
-		CurrentTimeExpr {
-			e.str()
-		}
-		CurrentTimestampExpr {
-			e.str()
-		}
 		Identifier {
-			e.str()
-		}
-		LocalTimeExpr {
-			e.str()
-		}
-		LocalTimestampExpr {
 			e.str()
 		}
 		NextValueExpr {
@@ -677,45 +658,6 @@ fn (e CountAllExpr) str() string {
 
 fn (e CountAllExpr) pstr(params map[string]Value) string {
 	return 'COUNT(*)'
-}
-
-struct CurrentDateExpr {
-}
-
-fn (e CurrentDateExpr) str() string {
-	return 'CURRENT_DATE'
-}
-
-struct CurrentTimeExpr {
-	prec int
-}
-
-fn (e CurrentTimeExpr) str() string {
-	return 'CURRENT_TIME(${e.prec})'
-}
-
-struct CurrentTimestampExpr {
-	prec int
-}
-
-fn (e CurrentTimestampExpr) str() string {
-	return 'CURRENT_TIMESTAMP(${e.prec})'
-}
-
-struct LocalTimeExpr {
-	prec int
-}
-
-fn (e LocalTimeExpr) str() string {
-	return 'LOCALTIME(${e.prec})'
-}
-
-struct LocalTimestampExpr {
-	prec int
-}
-
-fn (e LocalTimestampExpr) str() string {
-	return 'LOCALTIMESTAMP(${e.prec})'
 }
 
 struct CreateSchemaStmt {

--- a/vsql/expr.v
+++ b/vsql/expr.v
@@ -12,7 +12,7 @@ fn expr_is_agg(conn &Connection, e Expr, row Row, params map[string]Value) !bool
 				return nested_agg_unsupported(e)
 			}
 		}
-		Predicate, UnsignedValueSpecification {
+		Predicate, UnsignedValueSpecification, DatetimeValueFunction {
 			return e.is_agg(conn, row, params)
 		}
 		CallExpr {
@@ -37,7 +37,6 @@ fn expr_is_agg(conn &Connection, e Expr, row Row, params map[string]Value) !bool
 			return true
 		}
 		Identifier, Value, NoExpr, RowExpr, QualifiedAsteriskExpr, QueryExpression,
-		CurrentDateExpr, CurrentTimeExpr, CurrentTimestampExpr, LocalTimeExpr, LocalTimestampExpr,
 		UntypedNullExpr, NextValueExpr {
 			return false
 		}
@@ -107,7 +106,7 @@ fn resolve_identifiers(conn &Connection, e Expr, tables map[string]Table) !Expr 
 			return BinaryExpr{resolve_identifiers(conn, e.left, tables)!, e.op, resolve_identifiers(conn,
 				e.right, tables)!}
 		}
-		Predicate, UnsignedValueSpecification {
+		Predicate, UnsignedValueSpecification, DatetimeValueFunction {
 			return e.resolve_identifiers(conn, tables)
 		}
 		CallExpr {
@@ -159,8 +158,7 @@ fn resolve_identifiers(conn &Connection, e Expr, tables map[string]Table) !Expr 
 		QualifiedAsteriskExpr {
 			return QualifiedAsteriskExpr{resolve_identifiers(conn, e.table_name, tables)! as Identifier}
 		}
-		CountAllExpr, Value, NoExpr, QueryExpression, CurrentDateExpr, CurrentTimeExpr,
-		CurrentTimestampExpr, LocalTimeExpr, LocalTimestampExpr, UntypedNullExpr {
+		CountAllExpr, Value, NoExpr, QueryExpression, UntypedNullExpr {
 			// These don't have any Expr properties to recurse.
 			return e
 		}

--- a/vsql/grammar.v
+++ b/vsql/grammar.v
@@ -10,6 +10,7 @@ type EarleyValue = BetweenPredicate
 	| ComparisonPredicatePart2
 	| Correlation
 	| CreateTableStmt
+	| DatetimeValueFunction
 	| DerivedColumn
 	| Expr
 	| GeneralValueSpecification
@@ -602,6 +603,9 @@ fn get_grammar() map[string]EarleyRule {
 	}
 	mut rule_datetime_literal_ := &EarleyRule{
 		name: '<datetime literal>'
+	}
+	mut rule_datetime_primary_2_ := &EarleyRule{
+		name: '<datetime primary: 2>'
 	}
 	mut rule_datetime_primary_ := &EarleyRule{
 		name: '<datetime primary>'
@@ -4963,6 +4967,12 @@ fn get_grammar() map[string]EarleyRule {
 		},
 	]}
 
+	rule_datetime_primary_2_.productions << &EarleyProduction{[
+		&EarleyRuleOrString{
+			rule: rule_datetime_value_function_
+		},
+	]}
+
 	rule_datetime_primary_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
 			rule: rule_value_expression_primary_
@@ -4970,7 +4980,7 @@ fn get_grammar() map[string]EarleyRule {
 	]}
 	rule_datetime_primary_.productions << &EarleyProduction{[
 		&EarleyRuleOrString{
-			rule: rule_datetime_value_function_
+			rule: rule_datetime_primary_2_
 		},
 	]}
 
@@ -13278,6 +13288,7 @@ fn get_grammar() map[string]EarleyRule {
 	rules['<date string>'] = rule_date_string_
 	rules['<datetime factor>'] = rule_datetime_factor_
 	rules['<datetime literal>'] = rule_datetime_literal_
+	rules['<datetime primary: 2>'] = rule_datetime_primary_2_
 	rules['<datetime primary>'] = rule_datetime_primary_
 	rules['<datetime term>'] = rule_datetime_term_
 	rules['<datetime type: 1>'] = rule_datetime_type_1_
@@ -14497,6 +14508,11 @@ fn parse_ast_name(children []EarleyValue, name string) ![]EarleyValue {
 		}
 		'<date literal: 1>' {
 			return [EarleyValue(parse_date_literal(children[1] as Value)!)]
+		}
+		'<datetime primary: 2>' {
+			return [
+				EarleyValue(parse_datetime_primary_2(children[0] as DatetimeValueFunction)!),
+			]
 		}
 		'<datetime type: 1>' {
 			return [EarleyValue(parse_date_type()!)]

--- a/vsql/std_datetime_value_expression.v
+++ b/vsql/std_datetime_value_expression.v
@@ -15,4 +15,8 @@ module vsql
 //~
 //~ <datetime primary> /* Expr */ ::=
 //~     <value expression primary>
-//~   | <datetime value function>
+//~   | <datetime value function>   -> datetime_primary_2
+
+fn parse_datetime_primary_2(e DatetimeValueFunction) !Expr {
+	return e
+}

--- a/vsql/std_datetime_value_function.v
+++ b/vsql/std_datetime_value_function.v
@@ -4,66 +4,160 @@ module vsql
 
 // Format
 //~
-//~ <datetime value function> /* Expr */ ::=
+//~ <datetime value function> /* DatetimeValueFunction */ ::=
 //~     <current date value function>
 //~   | <current time value function>
 //~   | <current timestamp value function>
 //~   | <current local time value function>
 //~   | <current local timestamp value function>
 //~
-//~ <current date value function> /* Expr */ ::=
+//~ <current date value function> /* DatetimeValueFunction */ ::=
 //~     CURRENT_DATE   -> current_date
 //~
-//~ <current time value function> /* Expr */ ::=
+//~ <current time value function> /* DatetimeValueFunction */ ::=
 //~     CURRENT_TIME                                               -> current_time1
 //~   | CURRENT_TIME <left paren> <time precision> <right paren>   -> current_time2
 //~
-//~ <current local time value function> /* Expr */ ::=
+//~ <current local time value function> /* DatetimeValueFunction */ ::=
 //~     LOCALTIME                                               -> localtime1
 //~   | LOCALTIME <left paren> <time precision> <right paren>   -> localtime2
 //~
-//~ <current timestamp value function> /* Expr */ ::=
+//~ <current timestamp value function> /* DatetimeValueFunction */ ::=
 //~     CURRENT_TIMESTAMP                                  -> current_timestamp1
 //~   | CURRENT_TIMESTAMP
 //~     <left paren> <timestamp precision> <right paren>   -> current_timestamp2
 //~
-//~ <current local timestamp value function> /* Expr */ ::=
+//~ <current local timestamp value function> /* DatetimeValueFunction */ ::=
 //~     LOCALTIMESTAMP                                     -> localtimestamp1
 //~   | LOCALTIMESTAMP
 //~     <left paren> <timestamp precision> <right paren>   -> localtimestamp2
 
-fn parse_current_date() !Expr {
-	return CurrentDateExpr{}
+type DatetimeValueFunction = CurrentDate
+	| CurrentTime
+	| CurrentTimestamp
+	| LocalTime
+	| LocalTimestamp
+
+fn (e DatetimeValueFunction) pstr(params map[string]Value) string {
+	return match e {
+		CurrentDate { 'CURRENT_DATE' }
+		CurrentTime { 'CURRENT_TIME(${e.prec})' }
+		LocalTime { 'LOCALTIME(${e.prec})' }
+		CurrentTimestamp { 'CURRENT_TIMESTAMP(${e.prec})' }
+		LocalTimestamp { 'LOCALTIMESTAMP(${e.prec})' }
+	}
 }
 
-fn parse_current_time1() !Expr {
-	return CurrentTimeExpr{default_time_precision}
+fn (e DatetimeValueFunction) eval(mut conn Connection, data Row, params map[string]Value) !Value {
+	match e {
+		CurrentDate {
+			now, _ := conn.now()
+
+			return new_date_value(now.strftime('%Y-%m-%d'))
+		}
+		CurrentTime {
+			if e.prec > 6 {
+				return sqlstate_42601('${DatetimeValueFunction(e).pstr(params)}: cannot have precision greater than 6')
+			}
+
+			return new_time_value(time_value(conn, e.prec, true))
+		}
+		CurrentTimestamp {
+			if e.prec > 6 {
+				return sqlstate_42601('${DatetimeValueFunction(e).pstr(params)}: cannot have precision greater than 6')
+			}
+
+			now, _ := conn.now()
+
+			return new_timestamp_value(now.strftime('%Y-%m-%d ') + time_value(conn, e.prec, true))
+		}
+		LocalTime {
+			if e.prec > 6 {
+				return sqlstate_42601('${DatetimeValueFunction(e).pstr(params)}: cannot have precision greater than 6')
+			}
+
+			return new_time_value(time_value(conn, e.prec, false))
+		}
+		LocalTimestamp {
+			if e.prec > 6 {
+				return sqlstate_42601('${DatetimeValueFunction(e).pstr(params)}: cannot have precision greater than 6')
+			}
+
+			now, _ := conn.now()
+
+			return new_timestamp_value(now.strftime('%Y-%m-%d ') + time_value(conn, e.prec, false))
+		}
+	}
 }
 
-fn parse_current_time2(prec string) !Expr {
-	return CurrentTimeExpr{prec.int()}
+fn (e DatetimeValueFunction) eval_type(conn &Connection, data Row, params map[string]Value) !Type {
+	return match e {
+		CurrentDate { new_type('DATE', 0, 0) }
+		CurrentTime { new_type('TIME WITH TIME ZONE', 0, 0) }
+		CurrentTimestamp { new_type('TIMESTAMP WITH TIME ZONE', 0, 0) }
+		LocalTime { new_type('TIME WITHOUT TIME ZONE', 0, 0) }
+		LocalTimestamp { new_type('TIMESTAMP WITHOUT TIME ZONE', 0, 0) }
+	}
 }
 
-fn parse_localtime1() !Expr {
-	return LocalTimeExpr{0}
+fn (e DatetimeValueFunction) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
+	return false
 }
 
-fn parse_localtime2(prec string) !Expr {
-	return LocalTimeExpr{prec.int()}
+fn (e DatetimeValueFunction) resolve_identifiers(conn &Connection, tables map[string]Table) !Expr {
+	return e
 }
 
-fn parse_current_timestamp1() !Expr {
-	return CurrentTimestampExpr{default_timestamp_precision}
+struct CurrentDate {}
+
+struct CurrentTime {
+	prec int
 }
 
-fn parse_current_timestamp2(prec string) !Expr {
-	return CurrentTimestampExpr{prec.int()}
+struct LocalTime {
+	prec int
 }
 
-fn parse_localtimestamp1() !Expr {
-	return LocalTimestampExpr{6}
+struct CurrentTimestamp {
+	prec int
 }
 
-fn parse_localtimestamp2(prec string) !Expr {
-	return LocalTimestampExpr{prec.int()}
+struct LocalTimestamp {
+	prec int
+}
+
+fn parse_current_date() !DatetimeValueFunction {
+	return CurrentDate{}
+}
+
+fn parse_current_time1() !DatetimeValueFunction {
+	return CurrentTime{default_time_precision}
+}
+
+fn parse_current_time2(prec string) !DatetimeValueFunction {
+	return CurrentTime{prec.int()}
+}
+
+fn parse_localtime1() !DatetimeValueFunction {
+	return LocalTime{0}
+}
+
+fn parse_localtime2(prec string) !DatetimeValueFunction {
+	return LocalTime{prec.int()}
+}
+
+fn parse_current_timestamp1() !DatetimeValueFunction {
+	return CurrentTimestamp{default_timestamp_precision}
+}
+
+fn parse_current_timestamp2(prec string) !DatetimeValueFunction {
+	return CurrentTimestamp{prec.int()}
+}
+
+fn parse_localtimestamp1() !DatetimeValueFunction {
+	return LocalTimestamp{6}
+}
+
+fn parse_localtimestamp2(prec string) !DatetimeValueFunction {
+	return LocalTimestamp{prec.int()}
 }


### PR DESCRIPTION
As a longer term effort to remove ast.v, expr.v and eval.v, this moves <datetime value function> and its subtypes into their respective locations.