### PR TITLE
GROUP BY: Remove explicit is_agg()

### DIFF
--- a/tests/group-by.sql
+++ b/tests/group-by.sql
@@ -233,7 +233,10 @@ FETCH FIRST 2 ROWS ONLY;
 -- X: 1.234
 
 EXPLAIN SELECT y, min(x) * avg(x) FROM foo GROUP BY y;
--- error 42601: syntax error: nested aggregate functions are not supported: MIN(":memory:".PUBLIC.FOO.X) * AVG(":memory:".PUBLIC.FOO.X)
+-- EXPLAIN: TABLE ":memory:".PUBLIC.FOO (X DOUBLE PRECISION, Y CHARACTER VARYING(32))
+-- EXPLAIN: ORDER BY ":memory:".PUBLIC.FOO.Y ASC
+-- EXPLAIN: GROUP BY (":memory:".PUBLIC.FOO.Y CHARACTER VARYING(32))
+-- EXPLAIN: EXPR (Y CHARACTER VARYING, COL2 DOUBLE PRECISION)
 
 SELECT y, min(x) * avg(x) FROM foo GROUP BY y;
--- error 42601: syntax error: nested aggregate functions are not supported: MIN(":memory:".PUBLIC.FOO.X) * AVG(":memory:".PUBLIC.FOO.X)
+-- error 42601: syntax error: unknown column: MIN(":memory:".PUBLIC.FOO.X)

--- a/vsql/std_aggregate_function.v
+++ b/vsql/std_aggregate_function.v
@@ -53,19 +53,6 @@ fn (e AggregateFunction) eval_type(conn &Connection, data Row, params map[string
 	}
 }
 
-fn (e AggregateFunction) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	match e {
-		AggregateFunctionCount {
-			return true
-		}
-		RoutineInvocation {
-			return e.is_agg(conn, row, params)!
-		}
-	}
-
-	return false
-}
-
 fn (e AggregateFunction) resolve_identifiers(conn &Connection, tables map[string]Table) !AggregateFunction {
 	match e {
 		AggregateFunctionCount { return AggregateFunction(e) }

--- a/vsql/std_between_predicate.v
+++ b/vsql/std_between_predicate.v
@@ -75,14 +75,6 @@ fn (e BetweenPredicate) eval(mut conn Connection, data Row, params map[string]Va
 	return new_boolean_value(result)
 }
 
-fn (e BetweenPredicate) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	if e.left.is_agg(conn, row, params)! || e.right.is_agg(conn, row, params)! {
-		return sqlstate_42601('nested aggregate functions are not supported: ${e.pstr(params)}')
-	}
-
-	return false
-}
-
 fn (e BetweenPredicate) resolve_identifiers(conn &Connection, tables map[string]Table) !BetweenPredicate {
 	return BetweenPredicate{e.not, e.symmetric, e.expr.resolve_identifiers(conn, tables)!, e.left.resolve_identifiers(conn,
 		tables)!, e.right.resolve_identifiers(conn, tables)!}

--- a/vsql/std_case_expression.v
+++ b/vsql/std_case_expression.v
@@ -90,23 +90,6 @@ fn (e CaseExpression) eval_type(conn &Connection, data Row, params map[string]Va
 	}
 }
 
-fn (e CaseExpression) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	match e {
-		CaseExpressionNullIf {
-			if e.a.is_agg(conn, row, params)! || e.b.is_agg(conn, row, params)! {
-				return sqlstate_42601('nested aggregate functions are not supported: ${CaseExpression(e).pstr(params)}')
-			}
-		}
-		CaseExpressionCoalesce {
-			for expr in e.exprs {
-				return expr.is_agg(conn, row, params)!
-			}
-		}
-	}
-
-	return false
-}
-
 fn (e CaseExpression) resolve_identifiers(conn &Connection, tables map[string]Table) !CaseExpression {
 	match e {
 		CaseExpressionNullIf {

--- a/vsql/std_cast_specification.v
+++ b/vsql/std_cast_specification.v
@@ -44,14 +44,6 @@ fn (e CastOperand) eval_type(conn &Connection, data Row, params map[string]Value
 	}
 }
 
-fn (e CastOperand) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return match e {
-		ValueExpression, NullSpecification {
-			e.is_agg(conn, row, params)!
-		}
-	}
-}
-
 fn (e CastOperand) resolve_identifiers(conn &Connection, tables map[string]Table) !CastOperand {
 	match e {
 		ValueExpression {
@@ -80,10 +72,6 @@ fn (e CastSpecification) eval(mut conn Connection, data Row, params map[string]V
 
 fn (e CastSpecification) eval_type(conn &Connection, data Row, params map[string]Value) !Type {
 	return e.target
-}
-
-fn (e CastSpecification) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return e.expr.is_agg(conn, row, params)!
 }
 
 fn (e CastSpecification) resolve_identifiers(conn &Connection, tables map[string]Table) !CastSpecification {

--- a/vsql/std_comparison_predicate.v
+++ b/vsql/std_comparison_predicate.v
@@ -69,14 +69,6 @@ fn (e ComparisonPredicate) eval(mut conn Connection, data Row, params map[string
 	})
 }
 
-fn (e ComparisonPredicate) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	if e.left.is_agg(conn, row, params)! || e.right.is_agg(conn, row, params)! {
-		return sqlstate_42601('nested aggregate functions are not supported: ${e.pstr(params)}')
-	}
-
-	return false
-}
-
 fn (e ComparisonPredicate) resolve_identifiers(conn &Connection, tables map[string]Table) !ComparisonPredicate {
 	return ComparisonPredicate{e.left.resolve_identifiers(conn, tables)!, e.op, e.right.resolve_identifiers(conn,
 		tables)!}

--- a/vsql/std_contextually_typed_value_specification.v
+++ b/vsql/std_contextually_typed_value_specification.v
@@ -36,10 +36,6 @@ fn (e NullSpecification) eval_type(conn &Connection, data Row, params map[string
 	return error('cannot determine type of untyped NULL')
 }
 
-fn (e NullSpecification) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return false
-}
-
 fn (e NullSpecification) resolve_identifiers(conn &Connection, tables map[string]Table) !NullSpecification {
 	return e
 }

--- a/vsql/std_datetime_value_expression.v
+++ b/vsql/std_datetime_value_expression.v
@@ -47,14 +47,6 @@ fn (e DatetimePrimary) eval_type(conn &Connection, data Row, params map[string]V
 	}
 }
 
-fn (e DatetimePrimary) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return match e {
-		ValueExpressionPrimary, DatetimeValueFunction {
-			e.is_agg(conn, row, params)!
-		}
-	}
-}
-
 fn (e DatetimePrimary) resolve_identifiers(conn &Connection, tables map[string]Table) !DatetimePrimary {
 	return match e {
 		ValueExpressionPrimary {

--- a/vsql/std_datetime_value_function.v
+++ b/vsql/std_datetime_value_function.v
@@ -104,10 +104,6 @@ fn (e DatetimeValueFunction) eval_type(conn &Connection, data Row, params map[st
 	}
 }
 
-fn (e DatetimeValueFunction) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return false
-}
-
 fn (e DatetimeValueFunction) resolve_identifiers(conn &Connection, tables map[string]Table) !DatetimeValueFunction {
 	return e
 }

--- a/vsql/std_group_by_clause.v
+++ b/vsql/std_group_by_clause.v
@@ -73,7 +73,7 @@ fn new_group_operation(select_exprs []DerivedColumn, group_exprs []Identifier, p
 
 	empty_row := new_empty_row(table.columns, table.name.str())
 	for expr in select_exprs {
-		if expr.expr.is_agg(conn, empty_row, params)! {
+		if is_agg(expr.expr)! {
 			columns << Column{Identifier{
 				custom_id: expr.expr.pstr(params)
 			}, expr.expr.eval_type(conn, empty_row, params)!, false}
@@ -149,7 +149,7 @@ fn (mut o GroupOperation) execute(rows []Row) ![]Row {
 
 	// Perform the aggregations functions.
 	for expr in o.select_exprs {
-		if expr.expr.is_agg(o.conn, rows[0], o.params)! {
+		if is_agg(expr.expr)! {
 			key := expr.expr.pstr(o.params)
 			for mut set in sets {
 				mut valid := false

--- a/vsql/std_like_predicate.v
+++ b/vsql/std_like_predicate.v
@@ -68,14 +68,6 @@ fn (e CharacterLikePredicate) eval(mut conn Connection, data Row, params map[str
 	return e.right.eval(mut conn, data, params)!
 }
 
-fn (e CharacterLikePredicate) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	if left := e.left {
-		return left.is_agg(conn, row, params)!
-	}
-
-	return false
-}
-
 fn (e CharacterLikePredicate) resolve_identifiers(conn &Connection, tables map[string]Table) !CharacterLikePredicate {
 	left := if t := e.left {
 		?RowValueConstructorPredicand(t.resolve_identifiers(conn, tables)!)

--- a/vsql/std_names_and_identifiers.v
+++ b/vsql/std_names_and_identifiers.v
@@ -78,10 +78,6 @@ pub:
 	custom_id string
 }
 
-fn (e Identifier) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return false
-}
-
 fn (e Identifier) resolve_identifiers(conn &Connection, tables map[string]Table) !Identifier {
 	if e.custom_id != '' {
 		return e

--- a/vsql/std_next_value_expression.v
+++ b/vsql/std_next_value_expression.v
@@ -31,10 +31,6 @@ fn (e NextValueExpression) eval_type(conn &Connection, data Row, params map[stri
 	return new_type('INTEGER', 0, 0)
 }
 
-fn (e NextValueExpression) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return false
-}
-
 fn (e NextValueExpression) resolve_identifiers(conn &Connection, tables map[string]Table) !NextValueExpression {
 	return NextValueExpression{conn.resolve_identifier(e.name)}
 }

--- a/vsql/std_null_predicate.v
+++ b/vsql/std_null_predicate.v
@@ -39,10 +39,6 @@ fn (e NullPredicate) eval(mut conn Connection, data Row, params map[string]Value
 	return new_boolean_value(value.is_null)
 }
 
-fn (e NullPredicate) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return e.expr.is_agg(conn, row, params)!
-}
-
 fn (e NullPredicate) resolve_identifiers(conn &Connection, tables map[string]Table) !NullPredicate {
 	return NullPredicate{e.expr.resolve_identifiers(conn, tables)!, e.not}
 }

--- a/vsql/std_predicate.v
+++ b/vsql/std_predicate.v
@@ -44,15 +44,6 @@ fn (e Predicate) eval_type(conn &Connection, data Row, params map[string]Value) 
 	return new_type('BOOLEAN', 0, 0)
 }
 
-fn (e Predicate) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return match e {
-		ComparisonPredicate, BetweenPredicate, CharacterLikePredicate, SimilarPredicate,
-		NullPredicate {
-			e.is_agg(conn, row, params)!
-		}
-	}
-}
-
 fn (e Predicate) resolve_identifiers(conn &Connection, tables map[string]Table) !Predicate {
 	match e {
 		ComparisonPredicate {

--- a/vsql/std_routine_invocation.v
+++ b/vsql/std_routine_invocation.v
@@ -86,27 +86,6 @@ fn (e RoutineInvocation) eval_type(conn &Connection, data Row, params map[string
 	return func.return_type
 }
 
-fn (e RoutineInvocation) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	mut arg_types := []Type{}
-	for arg in e.args {
-		arg_types << arg.eval_type(conn, row, params)!
-	}
-
-	func := conn.find_function(e.function_name, arg_types)!
-
-	if func.is_agg {
-		return true
-	}
-
-	for arg in e.args {
-		if arg.is_agg(conn, row, params)! {
-			return sqlstate_42601('nested aggregate functions are not supported: ${e.pstr(params)}')
-		}
-	}
-
-	return false
-}
-
 fn (e RoutineInvocation) resolve_identifiers(conn &Connection, tables map[string]Table) !RoutineInvocation {
 	return RoutineInvocation{e.function_name, e.args.map(it.resolve_identifiers(conn,
 		tables)!)}

--- a/vsql/std_row_value_constructor.v
+++ b/vsql/std_row_value_constructor.v
@@ -89,23 +89,6 @@ fn (e ContextuallyTypedRowValueConstructor) eval_type(conn &Connection, data Row
 	}
 }
 
-fn (e ContextuallyTypedRowValueConstructor) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return match e {
-		CommonValueExpression, BooleanValueExpression, NullSpecification {
-			e.is_agg(conn, row, params)!
-		}
-		[]ContextuallyTypedRowValueConstructorElement {
-			for element in e {
-				if element.is_agg(conn, row, params)! {
-					return true
-				}
-			}
-
-			return false
-		}
-	}
-}
-
 fn (e ContextuallyTypedRowValueConstructor) resolve_identifiers(conn &Connection, tables map[string]Table) !ContextuallyTypedRowValueConstructor {
 	match e {
 		CommonValueExpression {
@@ -149,14 +132,6 @@ fn (e ContextuallyTypedRowValueConstructorElement) eval_type(conn &Connection, d
 	}
 }
 
-fn (e ContextuallyTypedRowValueConstructorElement) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return match e {
-		ValueExpression, NullSpecification {
-			e.is_agg(conn, row, params)!
-		}
-	}
-}
-
 fn (e ContextuallyTypedRowValueConstructorElement) resolve_identifiers(conn &Connection, tables map[string]Table) !ContextuallyTypedRowValueConstructorElement {
 	match e {
 		ValueExpression {
@@ -190,14 +165,6 @@ fn (e RowValueConstructorPredicand) eval_type(conn &Connection, data Row, params
 	return match e {
 		CommonValueExpression, BooleanPredicand {
 			e.eval_type(conn, data, params)!
-		}
-	}
-}
-
-fn (e RowValueConstructorPredicand) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return match e {
-		CommonValueExpression, BooleanPredicand {
-			e.is_agg(conn, row, params)!
 		}
 	}
 }
@@ -291,14 +258,6 @@ fn (r RowValueConstructor) eval_row(mut conn Connection, data Row, params map[st
 	}
 }
 
-fn (e RowValueConstructor) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return match e {
-		CommonValueExpression, BooleanValueExpression, ExplicitRowValueConstructor {
-			e.is_agg(conn, row, params)!
-		}
-	}
-}
-
 fn (e RowValueConstructor) resolve_identifiers(conn &Connection, tables map[string]Table) !RowValueConstructor {
 	match e {
 		CommonValueExpression {
@@ -333,10 +292,6 @@ fn (e ExplicitRowValueConstructor) eval(mut conn Connection, data Row, params ma
 
 fn (e ExplicitRowValueConstructor) eval_type(conn &Connection, data Row, params map[string]Value) !Type {
 	return sqlstate_42601('invalid expression provided: ${e.pstr(params)}')
-}
-
-fn (e ExplicitRowValueConstructor) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return false
 }
 
 fn (e ExplicitRowValueConstructor) resolve_identifiers(conn &Connection, tables map[string]Table) !ExplicitRowValueConstructor {

--- a/vsql/std_set_clause_list.v
+++ b/vsql/std_set_clause_list.v
@@ -54,14 +54,6 @@ fn (e UpdateSource) eval_type(conn &Connection, data Row, params map[string]Valu
 	}
 }
 
-fn (e UpdateSource) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return match e {
-		ValueExpression, NullSpecification {
-			e.is_agg(conn, row, params)!
-		}
-	}
-}
-
 fn (e UpdateSource) resolve_identifiers(conn &Connection, tables map[string]Table) !UpdateSource {
 	match e {
 		ValueExpression {

--- a/vsql/std_similar_predicate.v
+++ b/vsql/std_similar_predicate.v
@@ -61,14 +61,6 @@ fn (e SimilarPredicate) eval(mut conn Connection, data Row, params map[string]Va
 	return e.right.eval(mut conn, data, params)
 }
 
-fn (e SimilarPredicate) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	if left := e.left {
-		return left.is_agg(conn, row, params)!
-	}
-
-	return false
-}
-
 fn (e SimilarPredicate) resolve_identifiers(conn &Connection, tables map[string]Table) !SimilarPredicate {
 	left := if t := e.left {
 		?RowValueConstructorPredicand(t.resolve_identifiers(conn, tables)!)

--- a/vsql/std_string_value_function.v
+++ b/vsql/std_string_value_function.v
@@ -85,36 +85,6 @@ fn (e CharacterValueFunction) eval_type(conn &Connection, data Row, params map[s
 	return new_type('CHARACTER VARYING', 0, 0)
 }
 
-fn (e CharacterValueFunction) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	match e {
-		CharacterSubstringFunction {
-			if e.value.is_agg(conn, row, params)! {
-				return sqlstate_42601('nested aggregate functions are not supported: ${e.pstr(params)}')
-			}
-			if from := e.from {
-				if from.is_agg(conn, row, params)! {
-					return sqlstate_42601('nested aggregate functions are not supported: ${e.pstr(params)}')
-				}
-			}
-			if @for := e.@for {
-				if @for.is_agg(conn, row, params)! {
-					return sqlstate_42601('nested aggregate functions are not supported: ${e.pstr(params)}')
-				}
-			}
-		}
-		RoutineInvocation {
-			return e.is_agg(conn, row, params)!
-		}
-		TrimFunction {
-			if e.source.is_agg(conn, row, params)! || e.character.is_agg(conn, row, params)! {
-				return sqlstate_42601('nested aggregate functions are not supported: ${e.pstr(params)}')
-			}
-		}
-	}
-
-	return false
-}
-
 fn (e CharacterValueFunction) resolve_identifiers(conn &Connection, tables map[string]Table) !CharacterValueFunction {
 	match e {
 		CharacterSubstringFunction {

--- a/vsql/std_value_expression.v
+++ b/vsql/std_value_expression.v
@@ -43,14 +43,6 @@ fn (e ValueExpression) eval_type(conn &Connection, data Row, params map[string]V
 	}
 }
 
-fn (e ValueExpression) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return match e {
-		CommonValueExpression, BooleanValueExpression {
-			e.is_agg(conn, row, params)!
-		}
-	}
-}
-
 fn (e ValueExpression) resolve_identifiers(conn &Connection, tables map[string]Table) !ValueExpression {
 	match e {
 		CommonValueExpression {
@@ -84,14 +76,6 @@ fn (e CommonValueExpression) eval_type(conn &Connection, data Row, params map[st
 	return match e {
 		NumericValueExpression, CharacterValueExpression, DatetimePrimary {
 			e.eval_type(conn, data, params)!
-		}
-	}
-}
-
-fn (e CommonValueExpression) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return match e {
-		NumericValueExpression, CharacterValueExpression, DatetimePrimary {
-			e.is_agg(conn, row, params)!
 		}
 	}
 }

--- a/vsql/std_value_expression_primary.v
+++ b/vsql/std_value_expression_primary.v
@@ -51,14 +51,6 @@ fn (e ValueExpressionPrimary) eval_type(conn &Connection, data Row, params map[s
 	}
 }
 
-fn (e ValueExpressionPrimary) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return match e {
-		ParenthesizedValueExpression, NonparenthesizedValueExpressionPrimary {
-			e.is_agg(conn, row, params)!
-		}
-	}
-}
-
 fn (e ValueExpressionPrimary) resolve_identifiers(conn &Connection, tables map[string]Table) !ValueExpressionPrimary {
 	return match e {
 		ParenthesizedValueExpression {
@@ -84,10 +76,6 @@ fn (e ParenthesizedValueExpression) eval(mut conn Connection, data Row, params m
 
 fn (e ParenthesizedValueExpression) eval_type(conn &Connection, data Row, params map[string]Value) !Type {
 	return e.e.eval_type(conn, data, params)
-}
-
-fn (e ParenthesizedValueExpression) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return e.e.is_agg(conn, row, params)!
 }
 
 fn (e ParenthesizedValueExpression) resolve_identifiers(conn &Connection, tables map[string]Table) !ParenthesizedValueExpression {
@@ -125,15 +113,6 @@ fn (e NonparenthesizedValueExpressionPrimary) eval_type(conn &Connection, data R
 		ValueSpecification, Identifier, AggregateFunction, CaseExpression, CastSpecification,
 		NextValueExpression, RoutineInvocation {
 			e.eval_type(conn, data, params)!
-		}
-	}
-}
-
-fn (e NonparenthesizedValueExpressionPrimary) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return match e {
-		ValueSpecification, AggregateFunction, CaseExpression, CastSpecification,
-		NextValueExpression, RoutineInvocation, Identifier {
-			e.is_agg(conn, row, params)!
 		}
 	}
 }

--- a/vsql/std_value_specification_and_target_specification.v
+++ b/vsql/std_value_specification_and_target_specification.v
@@ -49,10 +49,6 @@ fn (e ValueSpecification) eval(mut conn Connection, data Row, params map[string]
 	}
 }
 
-fn (e ValueSpecification) is_agg(conn &Connection, row Row, params map[string]Value) !bool {
-	return false
-}
-
 fn (e ValueSpecification) resolve_identifiers(conn &Connection, tables map[string]Table) !ValueSpecification {
 	return e
 }


### PR DESCRIPTION
This was left over from the previous refactoring. While the previous error description is more helpful we must rely on the fallback error until a better solution can be added.