### PR TITLE
docs: SQL Standard

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -7,3 +7,4 @@ Development
    benchmark.rst
    contributing.rst
    testing.rst
+   sql-standard.rst

--- a/docs/sql-standard.rst
+++ b/docs/sql-standard.rst
@@ -1,0 +1,26 @@
+SQL Standard
+============
+
+`ISO/IEC 9075 <https://www.iso.org/standard/76583.html>`_ is the formal name for
+what is more colloquially known as the *SQL standard*. Every few years a new
+`version is published <https://en.wikipedia.org/wiki/SQL#Standardization_history>`_.
+
+Each version is split into multiple parts.
+`Part 2: Foundation (SQL/Foundation) <https://www.iso.org/standard/76584.html>`_
+is the largest part (in terms of pages) and covers the syntax and behavior for
+the core SQL language. It's also the most relevant part for this project.
+
+Each version brings new features, but most of the general features commonly used
+have been published by 2003 **and that will be the ideal standard for us to work
+against.** Older versions (such as 1999) are still relevant and helpful because
+they still contain most of the core features.
+
+**Unfortunately, the SQL Standard is not free (and is very expensive).** This
+includes all previous versions. This is obviously a challenge for an open-source
+project. While we cannot include a copy of the standard, the next best option is
+to provide a list of locations where it exists:
+
+* `SQL:2003 (working draft) <https://synthesis.frccsc.ru/synthesis/student/oodb/essayRef/sqlFoundation.pdf>`_
+* `SQL:1999 (final draft) (1) <https://web.cecs.pdx.edu/~len/sql1999.pdf>`_
+* `SQL:1999 (final draft) (2) <http://courses.cms.caltech.edu/cs123/sql99std/ansi-iso-9075-2-1999.pdf>`_
+* `SQL-99 Complete, Really <https://sql-99.readthedocs.io/en/latest/>`_ is the digitized version of `the book with the same name <https://www.amazon.com/SQL-99-Complete-Really-Peter-Gulutzan/dp/0879305681>`_ brought to you by CrateDB.


### PR DESCRIPTION
Unfortunately, the SQL Standard is not free (and is very expensive). This includes all previous versions. This is obviously a challenge for an open-source project. While we cannot include a copy of the standard, the next best option is to provide a list of locations where it exists.

So far I have been developing against SQL:2016, but we'll slowly roll this back to SQL:2003.