### PR TITLE
testing: Comments are now supported

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -227,6 +227,33 @@ There are slightly different forms depending on the type of the host parameter:
 - ``/* set b 'foo' */`` for string values.
 - ``/* set b NULL BOOLEAN */`` for ``NULL`` values (must specify a type).
 
+Comments
+^^^^^^^^
+
+Ordinary comments are collected for the expected output. If you want to place an
+ignored comment line you can prefix the line with ``-- #``:
+
+.. code-block:: sql
+
+   -- # This test adds some numbers.
+   VALUES 1 + 2;
+   -- COL1: 3
+
+While the placement of comment lines does not matter, it is by convention that
+comments pertaining to a specific test be joined (without a blank line) and
+comments relating to the entire file or group of tests below use a empty line
+separator:
+
+.. code-block:: sql
+
+   -- # The following tests are arithmetic.
+
+   VALUES 1 + 2;
+   -- COL1: 3
+
+   VALUES 3 * 4;
+   -- COL1: 12
+
 Multiple Connections
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/testing-comments.sql
+++ b/tests/testing-comments.sql
@@ -1,0 +1,10 @@
+-- # The following tests are arithmetic.
+
+-- # Adding
+VALUES 1 + 2;
+-- COL1: 3
+
+VALUES 3 * 4;
+-- # Comments can be nested,
+-- COL1: 12
+-- # .. and afterwards.

--- a/vsql/sql_test.v
+++ b/vsql/sql_test.v
@@ -72,6 +72,8 @@ fn get_tests() ![]SQLTest {
 				} else {
 					panic('bad directive: "${contents}"')
 				}
+			} else if line.starts_with('-- #') {
+				continue
 			} else if line.starts_with('-- ') {
 				expected << line[3..]
 			} else {


### PR DESCRIPTION
Not sure why it took me so long to implement, but you can now add comments to tests by using `-- #`.