### PR TITLE
update description of `make cli-test` in testing.rst, to match Makefile target

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -54,7 +54,7 @@ To run all CLI tests:
 
 .. code-block:: sh
 
-   make cli-tests
+   make cli-test
 
 Or, to run a single command test use the path without the ``.sh`` suffix:
 


### PR DESCRIPTION
The target is named `cli-test`, but the description was for `make cli-tests`. I am not sure what is the intended name, and whether it is already used in other scripts, so it seemed safer to update the text in the description.