### PR TITLE
chore: add `pub` access modifier to publicly used struct fields

### DIFF
--- a/vsql/server.v
+++ b/vsql/server.v
@@ -12,6 +12,7 @@ mut:
 }
 
 pub struct ServerOptions {
+pub:
 	db_file string
 	port    int
 	verbose bool


### PR DESCRIPTION
Hey @elliotchance :wave: 

This one is the only required to get going https://github.com/vlang/v/pull/21183 and keep vsql in CI. 
The other ones are extra. Sorry for the spam :sweat_smile: 
