### PR TITLE
ci: bump sphinx to minimum required version; update workflow action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up V version latest
-        uses: nocturlab/setup-vlang-action@v1
+        uses: vlang/setup-v@v1.4
         with:
-          id: v
-          v-version: master
+          check-latest: true
 
       - name: Verify fmt
         run: make fmt-verify
@@ -52,13 +51,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up V version latest
-        uses: nocturlab/setup-vlang-action@v1
+        uses: vlang/setup-v@v1.4
         with:
-          id: v
-          v-version: master
+          check-latest: true
 
       - name: Build macOS binaries
         run: |
@@ -78,13 +76,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up V version latest
-        uses: nocturlab/setup-vlang-action@v1
+        uses: vlang/setup-v@v1.4
         with:
-          id: v
-          v-version: master
+          check-latest: true
 
       - name: Build linux binaries
         run: |
@@ -107,13 +104,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up V version latest
-        uses: nocturlab/setup-vlang-action@v1
+        uses: vlang/setup-v@v1.4
         with:
-          id: v
-          v-version: master
+          check-latest: true
 
       - name: Build Windows binaries
         run: |

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==4.2.0
+sphinx==5.0.0
 sphinx_rtd_theme==1.0.0
 readthedocs-sphinx-search==0.1.1


### PR DESCRIPTION
Resolves the current CI failure with the latest PRs + additional warnings.

_For convenience, the link to the CI run on the PR branch:_ https://github.com/ttytm/vsql/actions/runs/8583796128/job/23523412637